### PR TITLE
When mechanisms_dir not defined, default to None and ignore

### DIFF
--- a/bmtk/simulator/utils/config.py
+++ b/bmtk/simulator/utils/config.py
@@ -313,7 +313,7 @@ class ConfigDict(dict):
 
     @property
     def mechanisms_dir(self):
-        return self.components['mechanisms_dir']
+        return self.components.get('mechanisms_dir', None)
 
     @property
     def biophysical_neuron_models_dir(self):


### PR DESCRIPTION
Fixes
https://github.com/AllenInstitute/bmtk/issues/48