### PR TITLE
Files aren't copied when running setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include bmtk *


### PR DESCRIPTION
Good evening.

Recently, I've had a couple lab members run into problems with python not copying the bionet utils scripts when running setup.py. Since those files don't exist in the python/anaconda library we run into the following error when running sim_setup:

```
(clean) C:\Users\Tyler\temp>python -m bmtk.utils.sim_setup -n ./network bionet
Traceback (most recent call last):
  File "C:\Users\Tyler\Anaconda3\envs\clean\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\Tyler\Anaconda3\envs\clean\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\Tyler\Anaconda3\envs\clean\lib\site-packages\bmtk-0.0.7-py3.7.egg\bmtk\utils\sim_setup.py", line 435, in <module>
    dt=options.dt, reports=reports)
  File "C:\Users\Tyler\Anaconda3\envs\clean\lib\site-packages\bmtk-0.0.7-py3.7.egg\bmtk\utils\sim_setup.py", line 201, in build_env_bionet
    copy_run_script(base_dir=base_dir, simulator=simulator, run_script='run_{}.py'.format(simulator))
  File "C:\Users\Tyler\Anaconda3\envs\clean\lib\site-packages\bmtk-0.0.7-py3.7.egg\bmtk\utils\sim_setup.py", line 173, in copy_run_script
    shutil.copy(os.path.join(simulator_path, run_script), os.path.join(base_dir, run_script))
  File "C:\Users\Tyler\Anaconda3\envs\clean\lib\shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "C:\Users\Tyler\Anaconda3\envs\clean\lib\shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Tyler\\Anaconda3\\envs\\clean\\lib\\site-packages\\bmtk-0.0.7-py3.7.egg\\bmtk\\utils\\scripts\\bionet\\run_bionet.py'
```

The fix is a simple one and should not affect any other processes. From what I can tell this will ensure that everything in the `bmtk` directory is copied when the project is built. If you see problems with merging I can have them include this file instead.

Thank you again,
Tyler