### PR TITLE
bionet nrn.py replace \\ with /

### DIFF
--- a/bmtk/simulator/bionet/nrn.py
+++ b/bmtk/simulator/bionet/nrn.py
@@ -55,8 +55,8 @@ def load_neuron_modules(mechanisms_dir, templates_dir, default_templates=True):
     h.load_file('stdgui.hoc')
 
     bionet_dir = os.path.dirname(__file__)
-    h.load_file(os.path.join(bionet_dir, 'import3d.hoc'))  # customized import3d.hoc to supress warnings
-    h.load_file(os.path.join(bionet_dir,'default_templates',  'advance.hoc'))
+    h.load_file(os.path.join(bionet_dir, 'import3d.hoc').replace("\\","/"))  # customized import3d.hoc to supress warnings
+    h.load_file(os.path.join(bionet_dir,'default_templates',  'advance.hoc').replace("\\","/"))
 
     if isinstance(mechanisms_dir, list):
         for mdir in mechanisms_dir:


### PR DESCRIPTION
Referencing issue 54 (https://github.com/AllenInstitute/bmtk/issues/54)

In Windows Neuron doesn't like the use of double slashes (`\\`) and we get the following error. 

```
(clean) C:\Users\Tyler\Desktop\BMTK Morpho Work\hippocampus-bmtk\ca3>python run_bionet.py simulation_config.json
2018-12-29 00:38:09,774 [INFO] Created log file
loading stuff
C:\Users\Tyler\Anaconda3\envs\clean\lib\site-packages\bmtk-0.0.7-py3.7.egg\bmtk\simulator\bionet
NEURON: Can't open  C:UsersTylerAnaconda3envscleanlibsite-packagemtk-0.0.7-py3.7.egmtksimulatoionetimport3d.hoc
 near line 1
character \010 at position 54 is not printable
 {xopen("C:UsersTylerAnaconda3envscleanlibsite-packagemtk-0.0.7-py3.7.egmtksimulatoionetimport3d.hoc")}
                                                                                                             ^
        xopen("C:UsersTyl...")
      execute1("{xopen("C:...")
    load_file("C:\Users\T...")
C:\Users\Tyler\Anaconda3\envs\clean\lib\site-packages\bmtk-0.0.7-py3.7.egg\bmtk\simulator\bionet\import3d.hoc
NEURON: Can't open  C:UsersTylerAnaconda3envscleanlibsite-packagemtk-0.0.7-py3.7.egmtksimulatoionetdefault_templatesadvance.hoc
 near line 1
character \010 at position 54 is not printable
 {xopen("C:UsersTylerAnaconda3envscleanlibsite-packagemtk-0.0.7-py3.7.egmtksimulatoionetdefault_templatesadvance.hoc")}
                                                                                                                             ^
        xopen("C:UsersTyl...")
      execute1("{xopen("C:...")
    load_file("C:\Users\T...")
NEURON: Import3d_SWC_read is not a template
 in BioAxonStub.hoc near line 25
        nl = new Import3d_SWC_read()
                             ^
        xopen("BioAxonStub.hoc")
      execute1("{xopen("Bi...")
    load_file("BioAxonStub.hoc")
NEURON: Import3d_SWC_read is not a template
 in Biophys1.hoc near line 24
        nl = new Import3d_SWC_read()
                             ^
        xopen("Biophys1.hoc")
      execute1("{xopen("Bi...")
    load_file("Biophys1.hoc")
```

Replacing marks in `bmtk/simulator/bionet/nrn.py` resolves the issue.
There should be no effect on current operation in Linux.