### PR TITLE
Spikes Analyzer - Keys to list change

### DIFF
--- a/bmtk/analyzer/visualization/spikes.py
+++ b/bmtk/analyzer/visualization/spikes.py
@@ -40,7 +40,7 @@ def _create_node_table(node_file, node_type_file, group_key=None, exclude=[]):
     node_types_df = pd.read_csv(node_type_file, sep=' ', index_col='node_type_id')
     nodes_h5 = h5py.File(node_file)
     # TODO: Use utils.spikesReader
-    node_pop_name = nodes_h5['/nodes'].keys()[0]
+    node_pop_name = list(nodes_h5['/nodes'])[0]
 
     nodes_grp = nodes_h5['/nodes'][node_pop_name]
     # TODO: Need to be able to handle gid or node_id


### PR DESCRIPTION
On my last pull request (#72) we changed the .keys() call to list() to accommodate h5 changes. This is a followup to maintain consistency in this file. Tutorial 4 is affected by this issue.

![image](https://user-images.githubusercontent.com/34382569/56428334-9bc38d00-6284-11e9-9816-e83deac574e7.png)
