### PR TITLE
Python 3 conflicts and changes causing tutorial 01 to not function.

### DIFF
--- a/bmtk/simulator/utils/scripts/convert_filters.py
+++ b/bmtk/simulator/utils/scripts/convert_filters.py
@@ -33,7 +33,7 @@ def convert_filters(src_dir, tgt_dir):
     for file_name in os.listdir(src_dir):
         if not pickle_regex.match(file_name) is None:
             
-            print 'Converting: %s' % file_name
+            print('Converting: %s' % file_name)
             
             full_path_to_src_file = os.path.join(src_dir, file_name)
             full_path_to_tgt_file = os.path.join(tgt_dir, file_name).replace('.pkl', '.nwb')
@@ -66,6 +66,6 @@ def convert_filters(src_dir, tgt_dir):
                 f.close()
                 
             except:
-                print '    Conversion failed: %s' % file_name
+                print ('    Conversion failed: %s' % file_name)
 
 

--- a/bmtk/utils/reports/spike_trains/plotting.py
+++ b/bmtk/utils/reports/spike_trains/plotting.py
@@ -135,7 +135,7 @@ class Filter(object):
                                 right_index=True)
 
             for grp_name, grp in nodes_df.groupby(group_by):
-                print grp_name, grp['node_ids'][:10]
+                print (grp_name, grp['node_ids'][:10])
 
 
 def _create_grouping(nodes_file, node_types_file, populations, group_by, node_ids_filter):

--- a/bmtk/utils/sim_setup.py
+++ b/bmtk/utils/sim_setup.py
@@ -437,7 +437,8 @@ class EnvBuilder(object):
         self._simulation_config['network'] = os.path.join(self.base_dir, 'circuit_config.json')
         self._add_run_params(**run_args)
         self._add_current_clamp(current_clamp)
-        self._add_spikes_inputs(spikes_inputs)
+        if spikes_inputs!=None:
+            self._add_spikes_inputs(spikes_inputs)
         if use_relative_paths:
             self._add_manifest(self._simulation_config, output_dir=self.output_dir)
         self._save_config(self._simulation_config, 'simulation_config.json')

--- a/docs/tutorial/01_single_cell_clamped.ipynb
+++ b/docs/tutorial/01_single_cell_clamped.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,17 +66,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "rm: cannot remove 'network/*': No such file or directory\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "rm network/*"
@@ -95,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,21 +104,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'node_type_id': 100, 'dynamics_params': '472363762_fit.json', 'potental': 'exc', 'morphology': 'Scnn1a_473845048_m.swc', 'node_id': 0, 'model_template': 'ctdb:Biophys1.hoc', 'model_type': 'biophysical', 'model_processing': 'aibs_perisomatic', 'cell_name': 'Scnn1a_473845048'}\n"
+      "{'cell_name': 'Scnn1a_473845048', 'potental': 'exc', 'model_type': 'biophysical', 'model_template': 'ctdb:Biophys1.hoc', 'model_processing': 'aibs_perisomatic', 'dynamics_params': '472363762_fit.json', 'morphology': 'Scnn1a_473845048_m.swc', 'node_type_id': 100, 'node_id': 0}\n"
      ]
     }
    ],
    "source": [
-    "from pprint import pprint\n",
     "for node in net.nodes():\n",
-    "    pprint(node)"
+    "    print(node)"
    ]
   },
   {
@@ -151,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,24 +209,161 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2019-07-20 23:27:02,626 [INFO] Created log file\n",
-      "2019-07-20 23:27:02,686 [INFO] Building cells.\n",
-      "2019-07-20 23:27:02,852 [INFO] Building recurrent connections\n",
-      "2019-07-20 23:27:02,866 [INFO] Running simulation for 2000.000 ms with the time step 0.100 ms\n",
-      "2019-07-20 23:27:02,868 [INFO] Starting timestep: 0 at t_sim: 0.000 ms\n",
-      "2019-07-20 23:27:02,869 [INFO] Block save every 5000 steps\n",
-      "2019-07-20 23:27:03,043 [INFO]     step:5000 t_sim:500.00 ms\n",
-      "2019-07-20 23:27:03,213 [INFO]     step:10000 t_sim:1000.00 ms\n",
-      "2019-07-20 23:27:03,391 [INFO]     step:15000 t_sim:1500.00 ms\n",
-      "2019-07-20 23:27:03,559 [INFO]     step:20000 t_sim:2000.00 ms\n",
-      "2019-07-20 23:27:03,568 [INFO] Simulation completed in 0.7023 seconds \n"
+      "2019-09-04 13:48:44,204 [INFO] Created log file\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:Created log file\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:44,676 [INFO] Building cells.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:Building cells.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:45,421 [INFO] Building recurrent connections\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:Building recurrent connections\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:45,454 [INFO] Running simulation for 2000.000 ms with the time step 0.100 ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:Running simulation for 2000.000 ms with the time step 0.100 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:45,463 [INFO] Starting timestep: 0 at t_sim: 0.000 ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:Starting timestep: 0 at t_sim: 0.000 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:45,483 [INFO] Block save every 5000 steps\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:Block save every 5000 steps\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:46,071 [INFO]     step:5000 t_sim:500.00 ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:    step:5000 t_sim:500.00 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:46,620 [INFO]     step:10000 t_sim:1000.00 ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:    step:10000 t_sim:1000.00 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:47,187 [INFO]     step:15000 t_sim:1500.00 ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:    step:15000 t_sim:1500.00 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:47,815 [INFO]     step:20000 t_sim:2000.00 ms\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:    step:20000 t_sim:2000.00 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-09-04 13:48:47,869 [INFO] Simulation completed in 2.415 seconds \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:NEURONIOUtils:Simulation completed in 2.415 seconds \n"
      ]
     }
    ],
@@ -301,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -325,147 +453,147 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>node_ids</th>\n",
-       "      <th>population</th>\n",
        "      <th>timestamps</th>\n",
+       "      <th>population</th>\n",
+       "      <th>node_ids</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>554.8</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>594.4</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>637.1</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>683.9</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>734.7</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>788.7</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>844.9</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>902.6</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>961.2</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1020.4</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1079.9</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1139.7</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1199.5</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1259.5</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1319.5</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1379.5</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1439.6</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
-       "      <td>0</td>\n",
-       "      <td>mcortex</td>\n",
        "      <td>1499.7</td>\n",
+       "      <td>mcortex</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "    node_ids population  timestamps\n",
-       "0          0    mcortex       554.8\n",
-       "1          0    mcortex       594.4\n",
-       "2          0    mcortex       637.1\n",
-       "3          0    mcortex       683.9\n",
-       "4          0    mcortex       734.7\n",
-       "5          0    mcortex       788.7\n",
-       "6          0    mcortex       844.9\n",
-       "7          0    mcortex       902.6\n",
-       "8          0    mcortex       961.2\n",
-       "9          0    mcortex      1020.4\n",
-       "10         0    mcortex      1079.9\n",
-       "11         0    mcortex      1139.7\n",
-       "12         0    mcortex      1199.5\n",
-       "13         0    mcortex      1259.5\n",
-       "14         0    mcortex      1319.5\n",
-       "15         0    mcortex      1379.5\n",
-       "16         0    mcortex      1439.6\n",
-       "17         0    mcortex      1499.7"
+       "    timestamps population  node_ids\n",
+       "0        554.8    mcortex         0\n",
+       "1        594.4    mcortex         0\n",
+       "2        637.1    mcortex         0\n",
+       "3        683.9    mcortex         0\n",
+       "4        734.7    mcortex         0\n",
+       "5        788.7    mcortex         0\n",
+       "6        844.9    mcortex         0\n",
+       "7        902.6    mcortex         0\n",
+       "8        961.2    mcortex         0\n",
+       "9       1020.4    mcortex         0\n",
+       "10      1079.9    mcortex         0\n",
+       "11      1139.7    mcortex         0\n",
+       "12      1199.5    mcortex         0\n",
+       "13      1259.5    mcortex         0\n",
+       "14      1319.5    mcortex         0\n",
+       "15      1379.5    mcortex         0\n",
+       "16      1439.6    mcortex         0\n",
+       "17      1499.7    mcortex         0"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -484,27 +612,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3Xl4VNX5wPHvm8lKCGELoKyBsBhQRFLEfWsFq0JttWK1UtfWQldrxVqt2tKq/VVbrUu1WneRuqZu1Iq2buyyLxJBIAISFtmyzsz7++PeCZNkZjIhk5nJ8H6eJ0/u3Dn35NzJ3HnnLPccUVWMMcaYcNISXQBjjDHJzQKFMcaYiCxQGGOMicgChTHGmIgsUBhjjInIAoUxxpiILFAYkwAiskJETk10OYyJhth9FMYYYyKxGoUxxpiILFAY00oi0ldEXhSRChHZISJ/FZFBIjLbfbxdRJ4Wkc5Bx3wmIl9NZLmNiZYFCmNaQUQ8wKvABmAA0BuYAQjwB+Bw4AigL3BLQgppTCulJ7oAxrRzY3CCwXWq6nX3ve/+LnN/V4jIXcBv4l04Y2LBAoUxrdMX2BAUJAAQkR7APcBJQB5O7X1X/ItnTOtZ05MxrbMJ6Ccijb90/QFQ4ChV7QRcgtMcZUy7Y4HCmNaZB2wBbheRXBHJFpETcGoR+4AvRaQ3cF0iC2lMa1igMKYVVNUHnAsUARuBcuBC4FbgGGA38BrwYqLKaExr2Q13xhhjIrIahTHGmIgsUBhjjInIAoUxxpiILFAYY4yJKCVuuOvevbsOGDAg0cUwxph2ZeHChdtVtaC5dCkRKAYMGMCCBQsSXQxjjGlXRGRDNOms6ckYY0xEFiiMMcZEZIHCGGNMRBYojDHGRGSBwhhjTEQWKIwxxkRkgcIYY0xEUQUKERkvImtEpExEpoV4PktEnnOfnysiA4Keu8Hdv0ZExjWXp4icISKLRGSxiLwvIkWtO0VjTHuxrmIfz87bSHWdL9FFMUGaDRTu4vH3AWcBxcBFIlLcKNkVwC5VLQLuBu5wjy0GJgHDgfHA/SLiaSbPB4CLVfVo4Bng1607RWNMMvjLf9Zyzr3vsWHH/rBpbnplOTe8uIzL/jGfWq8/jqUzkURToxgDlKnqOlWtBWYAExulmQg87m4/D5whIuLun6GqNaq6Hmex+THN5KlAJ3c7H9h8cKdmjEkmT87ZwPLP9/CDpxaFDQJrtu4j05PGR+t2cOebq+NcQhNONIGiN866wAHl7r6QadxF5ncD3SIcGynPK4HXRaQc+C5we6hCicjVIrJARBZUVFREcRrGmLbyyuLPeeT99fj94RdCq6z1Utg9l1Vb9vDwe+vCpvnucf25ZGw/HvlgPR9v3NVWRTYtEE2gCLUgfON3Q7g0Ld0P8DPg66raB/gHcFeoQqnqQ6paoqolBQXNzmlljGkjdT4/P31uMb99dSX3v1sWMo3fr1TW+pgw8nDOGtGLe95ey8YdlQ3SqCpVdT46ZHq4fvwweuZlc8OLy6jzWRNUokUTKMqBvkGP+9C0Oag+jYik4zQZ7YxwbMj9IlIAjFTVue7+54DjozoTY0xC7Kv2ElhR+e7/rGXl5j1N0lS5ndO5WR5uPrcYT5pw26srG6SprvOjCjmZHvKyM7hlQjGrt+7liY+imrfOtKFoAsV8YLCIFIpIJk7ndGmjNKXAZHf7fGC2OotxlwKT3FFRhcBgYF6EPHcB+SIyxM3ra8Cqgz89Y0xr+PzKJX+fyw+eXBh2JNL+Wi8AN379CDrnZHDjy8uaNEEF0nTITOew/Bx+dPpg/rPqC95ds60+TWUgTYYHgHHDe3HKkAL+/NYnbNtbHfNzM9FrNlC4fQ5TgVk4H9ozVXWFiNwmIhPcZI8A3USkDPg5MM09dgUwE1gJvAlMUVVfuDzd/VcBL4jIEpw+iutid7rGmJb4tGIf75dt580VW/ndaytDpqmsdQLI4Z1zuPHsI/h445fMmL+pYZqaAzUKgMtPHEBh91xu+9fK+o7tQD4dMp3VD0SEWyYMp8br5/bXrWM7kaK6j0JVX1fVIao6SFWnu/tuVtVSd7taVS9Q1SJVHaOq64KOne4eN1RV34iUp7v/JVU9UlVHquqpwXkZY+Lrs+3OUNYxhV15as5G3l+7vUma/TVuTSDLw3mjenNsYVfunLWaXftrD6QJqlEAZKV7uPmcYtZt389jH64HDjRP5WR66o8r7J7LVScX8uLHnzP/s51tcIYmGnZntjGHqOo6Hz+Z8TEPvPtp2DSBD+9bzh1OYfdcbnplOTXehk1QgZpAbmY6IsKtE4ezt9rL//17Tcg0AacN68EZw3rwl/+sZdue6qAahYdgU04r4vD8bG56eTle69hOCAsUxhyiPlq3g1cWb+aON1fz7LyNIdNUuR/eXXIz+M25xazfvp+/v7e+QZr6GoX7AT+sVycuPa4/z8zbyLLy3Q3TZDUMAjedU0ydT7n9jdX1fRQ5jQJFh8x0bjrH6dh+ao51bCeCBQpjDlE79zlNQ/26duC3r65k087KJmkC3/JzMjycOrQH44b35N7Za/n8y6omaXKzDtQWfva1IXTLzeTm0uX1Q2OhYY0CYED3XK48yWla+qDMadbqkNl0hebxI3px0uDu/OmtT6jYW9Oa0zYHwQKFMSlq+74afM3cAAdwz0WjEOBXLy1DtWH6xv0GN53jzLTzu6ChrYH+h9ygmkCn7AymneV0bL+wqLxJrSPYlNOK6NUpm/ve+TRsmkDHdnWdj9vfsI7teLNAYUwKWlr+Jcf/YTbfeXhOkz6FgMC3/ME9OvLL8cN4b+12Xl26pUGa6jofaQKZHuejok+XDkw9rYg3lm+tH9oaGNHUIathTeCbo3ozun8Xbn9jNVt3O8Nbc7Oa1hZys9K54evDGjwOZVBBR644cSAvLCpn4Qbr2I4nCxTGpKCPPt1Brc/P3PU7+UOYoaX7g5qVLhnbnyN75/PbV1eyp7quPk1lrY+cDA/O1G2Oq04eyMDuufymdAXVdb76GkVORsOaQFqacOuE4eyqrOVPb30ChK4tAEwYeXj9dscQTU8BPzq9iMPys7np5RURa0smtixQGJOCAkHg0uP689iHnzFvfdNv4FW1XnIyPKSlCZ40Yfp5I6jYV8Nd//7kQJo6HzmNPriz0j3cOnE4G3ZU8rf/rqsPJp60pjPzjOidz8XH9g86NvRHjojw/vWncce3jiS/Q0bY88rNSufGs49g5ZY9PD3XOrbjxQKFMSkoEASuHz+Mvl1zuP6FpU3urK6s9TX4hn9Un858d2x/nvjos/rRStW1PnIym35MnDS4gHOOOoz73i1j1ZY99TfShXLtmUPqt4NrJo316dKBC7/Sr9lzO/vIwzh+UDf+b9Yaduyzju14sEBhTDuzYvNuvnbXf3nk/fVh0+x3g0BuVjp/OO8o1m/fz/2N7peorPU1GYp67ZlD6ZqbxY0vL8PnjlbqkBG6Keimc4rJ9KTx3trtTfIJ1rlDJo9fPoabz2m8jM3BERFumzicylofd9hU5HFhgcKYdqZ08WbWbtvHb19dyZvLt4ZMU1Xrq79n4cTB3TlvVG8eeLeMsm1769NU1nqbDFfNz8ngpnOOYGn5bp6Zu4GqOh/ZYYJAz07Z/OxrTm1h086qkGkCThlSwOUnFkZ9js0p6pHHFScWMnNBOYtsKvI2Z4HCmHZm655qenfO4cje+Ux7cSnb9jSdMK+y1tugJnDj2UeQm5XOr15cXj9hX6gaBTgdyycUdePOWWvYtLOSnIzwHxOTj+tP7845nDY0/lP9/+iMwfTslMXNryy3ju02ZoHCmHamqtZHXnY6f5l0NJW1Pm7514omaRoHge4ds/jVWUcw77Od/HPhpvo04e5Z+O3EEdTU+Vm3fX/IG+AC0j1pvH3tKTxwyegYnFnLdMxK58azi1n++Z6wd5ab2LBAYUySaXzTW2POSCQPAws68pMzBvP6sq28tfKLBmkqa31NOpgvKOnDmMKu/P711WzfV+MGitBBYGBBR35w6iAAVm1pur5EsOwMD9kZ4fso2tK5Rx3GcQO78cdZa9gZNAmhiS0LFMYkkXfWbGPEb2Zx3zuhV4oDp0YRuGfh6pMHMqxXHje9vJy9Te5/aBgERITfnzeCylovv3t1pdM8FaET+oenDqJPlxwuPrb5kUiJEpiEcH+Nlz/Oso7ttmKBwpgk8q/Fm9lf6+OPs9bwyuLPQ6YJLBcKkOFJ4w/fPJIv9lbzx1kHZmutChMEinrkcc2pRby8eDMbdlRGHNaaneHhvV+extTTB7fyrNrWkJ55fO/4AcyYv4klm75MdHFSkgUKY5LIvhovRT06cky/zvz65eUNJt8LqKrzNWjqGdWvC5OPG8CTczbUT22xP0TTU8APTx3EwO65AKRFuK8BIt/3kEx+8tXBdO+YxU3Wsd0mLFAYk0Sq6pyO6rsvPBq/X/nl80uaTtQX1PQUcN24oRyen8Mvn3durKsK0fQUkJ3h4XfnjQCcu6xTQV52Br8+2xnW++RHnyW6OCnHAoUxSSQwEql/t1xu+PoRfFC2g+caLSsa3PQUkJuVzu+/eSSfVuznvnfKmu1/OH5Qd2ZcPZaffDW5m5VaYsLIwzl5SAF3zlpD+a6mU6abg2eBwpg48fr8LC3/MuIqbcGd0N8Z04+xA7sy/bVVbNl9oAmqqjb0TXCnDCngm8f05t7ZZfi16SJBjY0d2I38nPDzKrU3gc56gF+9tLzZ0WMmelEFChEZLyJrRKRMRKaFeD5LRJ5zn58rIgOCnrvB3b9GRMY1l6eIvCcii92fzSLycutO0ZjkcM/sMib89QOufnJh2GAR3Amdlibc8a2j8PqVX73orBXh9ys1Xn+TpqeAm84uJtCtkCrNSi3Rp0sHfjluKP/7pIKXPg49GMC0XLOBQkQ8wH3AWUAxcJGINJ605Qpgl6oWAXcDd7jHFgOTgOHAeOB+EfFEylNVT1LVo1X1aOAj4MXWn6YxiRfoaJ69elvYOYoa3wTXv1su140byjtrnA++au+BqcFD6ZKbyR/PH+lsR5iFNZV997gBHNOvM7e9upLtNmlgTERToxgDlKnqOlWtBWYAExulmQg87m4/D5whznCJicAMVa1R1fVAmZtfs3mKSB5wOmA1CpMStu6u5qwRvbhkbD8efm89H7pLfwarCjGtxuTjBzC6fxdu/ddKNuxw2t4j9T+cP7oPr/7oRCYe3Tu2J9BOeNyaWGWNj1v/tbL5A0yzogkUvYHg3rRyd1/INKrqBXYD3SIcG02e5wFvq2rI20JF5GoRWSAiCyoqKqI4DWMSq7rOT06mhxu/XszA7rn84p9LGiwSpKpUhuio9qQJd55/FFV1Pq6duQSg2TuhR/TOD7k+xKFicM88ppxWxL+WbObtVV80f4CJKJpAEerd1riXKFyalu4PdhHwbLhCqepDqlqiqiUFBfGfkMyYlqp273/IyfRw14VH88XeGm4tPfCNt9bnx+fXkNNqDCroyM+/NoSV7nQakab1No5rTh3E0J55/LrRXeum5aIJFOVA36DHfYDN4dKISDqQD+yMcGzEPEWkG07z1GvRnIQx7UF13YH7H47u25kfnjqIFxaV8+8VzlThgbWnw/U/XHliIZnuCnGRmp6MIzM9jdu/dSRb91Tz+zDLwZroRBMo5gODRaRQRDJxOqdLG6UpBSa72+cDs9UZm1YKTHJHRRUCg4F5UeR5AfCqqjadP9mYJLRldxV3vrmaz7bvD5um2usnO2jK7h+dPpjiwzrxq5eWsWNfDZXuCnThgkC6J43XfnQiJxR1Y8Th+bE9gRQ1ql8XrjppIM/O28h/P7Em6oPVbKBw+xymArOAVcBMVV0hIreJyAQ32SNANxEpA34OTHOPXQHMBFYCbwJTVNUXLs+gPzuJCM1OxiSbu9/6hPvf/ZTzH/yQjTua3uxV5zYrZQcNWc1MT+OuC0eyp8rLr19eTlWtF4jcrDS4Zx5PXzmWHp2yY38SKernXxtCUY+OXP/8UnZXWRPUwYjqPgpVfV1Vh6jqIFWd7u67WVVL3e1qVb1AVYtUdYyqrgs6drp73FBVfSNSnkHPnaqqb8bmFI1pe+W7qujSIYNar58fPLWwyfrUVe7jxkFgWK9O/OxrQ3hj+VaeneeM74i0/oNpuewMD3d9eyQV+2q4NcTaHaZ5dme2MTFQVedjRO98/jzpaFZu2cMfXl/V4PlA4MgK0f9w9ckDGd2/S/0a2Nb/EHtH9enMlFMH8eKiz+v7hEz0LFAYEwNVtc6IptOH9eSKEwt5/KMNvLN6W/3zNXXOndjZ6U0vOU+a8KcLRtY/zs2yGkVbmBrUJ2SLHLWMBQpjYiB4or7rxg1lWK88rnt+CRV7nTuDq8M0PQUM6J7LLecWk+ERDs+3/oe2kJmexp++PZLdVXXc9MryRBenXbFAYUwMBE/9nZ3h4Z6LRrG32ls/TXigjyI7wvxL3zuhkGW3jLOO6jZ0xGGd+OlXh/Da0i38a0njUf4mHAsUxsRA46k3hvTM41dfP4J31lTw5JwNVLtNT83dKJeotacPJd8/eSAj+3bmpleWs3W3jcCPhgUKY5rx2fb9THl6EW8s2xI2TVVd08WELj2uP6cNLWD6a6tY9vlugAb3UZjESPekcfe3R1JT5+fafy7GbyviNcvetcY046k5G3ht2RaueXoRpSGaK+p8frx+bRIoRIQ7zx9Jx6x0fvuqM1WH1RiSw8CCjvzm3GI+KNtRP9rMhGeBwphmrN22j6IeHRlT2JXr/rmElZsbzlNZWRu+o7ogL4s7zz+q/nG46TlM/F34lb6MG96TO2etZrlb4zOhWaAwphm7q+o4LD+b+y8+hvycDKY8s6jBJHPNjWg644ienD6sBwBdOmS2fYFNVESE2795FF1zM/nJjI+pqvU1f9AhygKFMc2odoe+du+Yxb0XjWLjzkpucFecgwM1ikg3yj18aQn/ve5UuuRaoEgmXXIzuevbR/NpxX6mv25rV4RjgcKYZlQGDX09dmA3rj1zCK8u3cIz8zYC1H8TjdSs5EkT+nfLbfvCmhY7oag7V588kKfmbOStlbZ2RSgWKIxpRlVdw6GvPzh5EKcMKeDWf61kxebdB+6RsP6HduvaM4dQfFgnrn9hKdv22JDZxixQGNOM6lofORkHptVISxPu+vZIunTIYOozH9fffW2T+bVfWenOTZKVtV5++txifDZktgELFMZEEFieNCez4aXSrWMW90waxYYd+7l25mLARjS1d0U9OnLbxBF8+OkO7p29NtHFSSoWKMwhze9Xnpm7scEEfsHqfIovxD0S4PRX/OyrQ9gfYXisaV8uGN2Hb47qzV/eXsuHZdsTXZykYYHCHNLmrNvBr15axmWPzeeBdz9t8nxz/Q8/PK2Inp2yAMjPyWi7gpq4EBF++40RDOyey49nLGbbXuuvAAsU5hC31L3R6rShBdzx5mpe/vjzBs/XeMOvIwHOaKZ//+wUHv1eCQV5WW1bWBMXuVnp3H/xaPbV1PEz668ALFCYQ9zuqjoyPWk8dGkJYwq7cv0LSxvcpVvrdSbzy/KEv1TyczI4fVjPNi+riZ+hvfK4bcIIPijbwX3vlCW6OAlngcIc0iprvHTI8pDhSeO+7xxD19xMvv/kwvqFbQKBIjPEgkMmtV1Q0ofzRvXmz//5hA8/PbT7K6J694vIeBFZIyJlIjItxPNZIvKc+/xcERkQ9NwN7v41IjKuuTzFMV1EPhGRVSLy49adojHh7a/1kesOay3Iy+LBS0ZTsa+GHz27CK/PT63PAsWhSkT43TdGMKB7Lj+ZsfiQvr+i2Xe/iHiA+4CzgGLgIhEpbpTsCmCXqhYBdwN3uMcWA5OA4cB44H4R8TST5/eAvsAwVT0CmNGqMzQmgspaL7lZB/ofRvbtzPRvOE0Od85ac6DpyQLFISk3K50HLh7NvmovP3x6Uf374VATzbt/DFCmqutUtRbng3tiozQTgcfd7eeBM0RE3P0zVLVGVdcDZW5+kfK8BrhNVf0Aqhp63KIxMbCvxtfkRrkLSvpy6XH9eeh/63hxkdO5bTWKQ9fQXnncef5RLNiwi+mvHZrzQUXz7u8NbAp6XO7uC5lGVb3AbqBbhGMj5TkIuFBEFojIGyIyOFShRORqN82CioqKKE7DmKYqa7whJ/P79dnFlPTvwmMffgZAZoTObJP6zh15OFedVMjjH23gxUXliS5O3EXz7pcQ+xqPFwuXpqX7AbKAalUtAR4GHg1VKFV9SFVLVLWkoKAgZMGNaU6N1x/yHonM9DTuv+SY+sd2M525fvwwxg7syg0vLjvk1q+IJlCU4/QZBPQBGi/zVZ9GRNKBfGBnhGMj5VkOvOBuvwQchTFtpNbrJ8MT6nsL9MjL5pUpJ/C14p4U9egY55KZZJPuSeOv7si4Hzy1kC8raxNdpLiJJlDMBwaLSKGIZOJ0Tpc2SlMKTHa3zwdmqzNZfykwyR0VVQgMBuY1k+fLwOnu9inAJwd3asbArBVbueaphXy8cVfI52t9fjLTw9cWRvbtzMOXltiEfwaA7h2zuP/iY9i2p4Yfzzh0bsZrNlC4fQ5TgVnAKmCmqq4QkdtEZIKb7BGgm4iUAT8HprnHrgBmAiuBN4EpquoLl6eb1+3At0RkGfAH4MrYnKo5FP3h9VW8sXwrFz40h3fWNB0XUev1W/+DaZFR/bpw68Th/O+TCv7v32sSXZy4iOprkqq+DrzeaN/NQdvVwAVhjp0OTI8mT3f/l8DZ0ZTLmEiq63x8tqOSy04YwPzPdvLDpxbx3PfHclSfzvVparx+G9FkWuyiMf1YWr6bB979lKE98/jGqMbje1KLXSEmZe2t9gIwsHsu//jeGLp1zOTyxxawaWdlfZo6n9/ukTAH5dYJwzm2sCu/fGFp2KbNVGFXiElZlbVOoOiQmU5BXhaPXfYVar0+Ln9sPnuq64DIndnGRJKZnsaDl4ymV6dsrnpiIZu/rEp0kdqMBQqTsvbXODO/Bu68LuqRx4OXjGb99v1MeXoRde4UHdb0ZA5Wl9xM/j65hOo6H1c9saD+y0mqsSvEpKz97kWbm3WgK+74ou78/ptH8t7a7fz6peX4/Eqmx+6RMAdvSM887rnoaFZu2cO1M5fgT8GRUBYoTMraX3Og6SnYt0v68sNTB/HcAmdyAKtRmNY6fVhPfnXWEbyxfCt/fjv1llG1K8SkrGp3dbpQy5j+4syhnDbUuaPf+ihMLFx5UiHnj+7DPW+vbbIAVntndxGZlFUTYS2JtDThgUtG88j765kw8vB4F82kIBFh+nkjKN9VyXXPL6FHpyyOH9Q90cWKCatRmJRV53PaisPdUJed4WHKaUX06JQdz2KZFJaV7uFvl5TQv1su339yIZ98sTfRRYoJCxQmZdnqdCYR8jtk8NhlXyE7w8Nl/5ifEgse2RVk2r1wo0xqvU4fhQUKE299unTg0clfYef+Wi5/fH79wIr2yq4g026pKt95eA5H3fpvHnfXjQgWaHqyzmqTCEf2yee+i0excvMepj7jLK3bXlmgMO3Whh2VfPjpDrx+P78pXcHtb6zGmbTYYetdm0Q7fVhPfvuNEbyzpoKbXlnR4P3ZntioJ9Nu7djvrAfwwMWjeXv1Fzz430/pkOnhx2c4iyIG+igy0ixQmMS5+Nj+lO+q4oF3P6WgYyY/P3NooovUYhYoTLtVE7hPItPDbRNGUFXr5663PiE3K50rTiyk1ufM45SWZk1PJrF+OW4oO/fVcs/sMjp3yOTyEwsTXaQWsUBh2q1qt7M6O8NDWppwx7eOpLLWy29fXUnHLI+tNWGSRuAeiy+rarnt1ZV0yc3gvFF9El2sqNlVZNqt6jqnaSk7w3kbp3vS+POkozllSAHTXlzGi4vKybD+CZMk0j1p/GXSKI4b2I3r/rmU2au/SHSRomZXkWm3AlN0ZAUtZZqV7uHBS0bzlQFd2VVZx5eVdYkqnjFNZGd4eOjS0Qw7LI9rnlrE/M92JrpIUbFAYdqtxjWKgJxMD49MLuHI3vkcP6hbIopmTFh52Rk8dtkYenfO4fLH5rNqy55EF6lZFihMuxWoUWSnN530Ly87g9KpJ/DYZWPiXSxjmtW9YxZPXDGG3Mx0vvvIXMq27Ut0kSKKKlCIyHgRWSMiZSIyLcTzWSLynPv8XBEZEPTcDe7+NSIyrrk8ReQxEVkvIovdn6Nbd4omVQUm/csOMTssOB2Idg+FSVZ9unTg6auOBYTvPDyHz7bvT3SRwmr2KhIRD3AfcBZQDFwkIsWNkl0B7FLVIuBu4A732GJgEjAcGA/cLyKeKPK8TlWPdn8Wt+oMTco60EdhwcC0T4MKOvLMVcfi9TuzDASv555MornCxgBlqrpOVWuBGcDERmkmAo+7288DZ4iIuPtnqGqNqq4Hytz8osnTmIiqvT4y09PsPgnTrg3pmcdTVxzL/lof3/n7nKRcezuaQNEb2BT0uNzdFzKNqnqB3UC3CMc2l+d0EVkqIneLSFaoQonI1SKyQEQWVFRURHEaJtXU1PnJttqESQHFh3fiySvG8OX+Oi7++9ykm3E2mqss1Ne1xhOWhEvT0v0ANwDDgK8AXYHrQxVKVR9S1RJVLSkoKAiVxKS46jpf2P4JY9qbo/p05rHLx/DFnmq+8/e5bN9Xk+gi1YsmUJQDfYMe9wE2h0sjIulAPrAzwrFh81TVLeqoAf6B00xlDmGBvohQ+y1QmFQyun8X/vG9r1C+q5JJD81JmppFNIFiPjBYRApFJBOnc7q0UZpSYLK7fT4wW51pEkuBSe6oqEJgMDAvUp4icpj7W4BvAMtbc4Kmfbv/3TKG3fQm3/7bR2zY0XBUSHWd3zqyTco5dmA3HrtsDJu/rGLSQ3PYujvxwaLZq8ztc5gKzAJWATNVdYWI3CYiE9xkjwDdRKQM+DkwzT12BTATWAm8CUxRVV+4PN28nhaRZcAyoDvwu9icqmmPZs7fRM9OWazZupdv3PcBizbuqn+u2ms1CpOaxg7sxhOXj2Hb3houfOgjPk9wB7e01/nRg5WUlOiCBQsSXQwTY16fnyG/foMppxXxrWP6MPkf8/hiTzUPXDya04b1YNIcFIMQAAAU5UlEQVRDH+HzK//8wfGJLqoxbeLjjbu49NF5dMrOYMbVY+nbtUNM8xeRhapa0lw6q7ebpFVZ58OvkJ+TwYDuubxwzfEU9ejIVU8s4JXFn1Nd57cahUlpo/p14Zkrx7Kvxsu3//YR6xN0U54FCpO0qmsPrDcBzrQHz141ltH9u/DT5xazeNOXDSYENCYVHdknn2evGkuN18+Ff/uIsm17414GCxQmaVUFFiYKqjXkZWfw+OVjOGNYTwBqvKFHRBmTSooP78SzV43Fr3DBgx+xtPzLuP59CxQmaVXWNg0U4Mzt9OAlx/CLM4cw5bSiRBTNmLgb2iuP539wHB0y0/nOw3OZs25H3P62BQqTtAI1iuzMps1L6Z40pp4+mLEDbRpxc+gI9NX1ys9m8qPzeHtVfBY/skBhklZ1mBqFMYeyXvnZzPz+cQzpmcf3n1zIx0FDxtuKrZltklaoPgpjDHTNzeSZq47lqTkbGdmnc5v/PQsUJmnVuutNZGVYxdeYxvKyM7jm1EFx+Vt2BZqkVetzAkWGx96mxiSSXYEmadX5nFkDMi1QGJNQdgWapFVnNQpjkoJdgSZpHQgUtoKdMYlkgcIkrUBndrrVKIxJKLsCTdKyPgpjkoNdgSbhFm/6kmtnLuHJORvqaxFgTU/GJAu7j8Ik3M9nLmZdxX5eWFTOjHkbueeiUQwq6Eidz48IeNIsUBiTSFajMAm1t7qOdRX7uW7cUP723dFs/rKKCfe+z6tLN1Pr85PhScNZFdcYkyhWozAJtWNfLQCH5WczbngvjuqTz5SnFzH1mY8BbE1sY5KAXYUmoQJ3XwcWIDosP4cZVx/H944fAEBNUJ+FMSYxogoUIjJeRNaISJmITAvxfJaIPOc+P1dEBgQ9d4O7f42IjGtBnveKyL6DOy3TXtTUOYEgM6jmkJmexi0ThvPgJaP5vwtGJqpoxhhXs01PIuIB7gO+BpQD80WkVFVXBiW7AtilqkUiMgm4A7hQRIqBScBw4HDgPyIyxD0mbJ4iUgK0/ZSIJuFqfc4MsaGamMaP6BXv4hhjQoimRjEGKFPVdapaC8wAJjZKMxF43N1+HjhDnB7IicAMVa1R1fVAmZtf2DzdwPRH4JetOzXTHgSaljKtL8KYpBXN1dkb2BT0uNzdFzKNqnqB3UC3CMdGynMqUKqqWyIVSkSuFpEFIrKgoqIiitMwycgChTHJL5qrM9TYRI0yTYv2i8jhwAXAvc0VSlUfUtUSVS0pKChoLrlJUvVrTligMCZpRXN1lgN9gx73ATaHSyMi6UA+sDPCseH2jwKKgDIR+QzoICJlUZ6LaYdqLFAYk/SiuTrnA4NFpFBEMnE6p0sbpSkFJrvb5wOzVVXd/ZPcUVGFwGBgXrg8VfU1Ve2lqgNUdQBQqapFrT1Jk7wO1ChsuVNjklWzo55U1SsiU4FZgAd4VFVXiMhtwAJVLQUeAZ50v/3vxPngx003E1gJeIEpquoDCJVn7E/PJLsarzPqyfoojEleUd2ZraqvA6832ndz0HY1Tt9CqGOnA9OjyTNEmo7RlM+0X4Eahc0Qa0zysqvTJFR9H0WGvRWNSVZ2dZqEshqFMcnPrk6TULVeP540sVXsjElidnWahKrx+qw2YUySsyvUJFSt12/9E8YkObtCTULVeP1WozAmydkVauJm+ee7ue+dMuas24FzP6ZTo7B7KIxJbrbCnYmLrburOf/BD6l215/4yoAu/Obc4VR7fWRn2F3ZxiQzCxQmLv6z6guq6/yUTj2BJeW7+fNbn3DuX99HFfp2zUl08YwxEVid38TFxp2VZKanMeLwfL47tj+zf3Eqk48bAEC/rh0SWzhjTERWozBx8cWeanp1yiYtzZlhPj8ng1smDOfyEwpt1JMxSc4ChYmLqlofOSH6Ivp1s9qEMcnOvsqZuKj2+sm2moMx7ZJduSYuaup8ZNnoJmPaJQsUJi6cGoUFCmPaIwsUJi5q6nxk2411xrRLduWauKiusxvrjGmvLFCYuKiu85NlNQpj2iW7ck1c1NhUHca0W1EFChEZLyJrRKRMRKaFeD5LRJ5zn58rIgOCnrvB3b9GRMY1l6eIPCIiS0RkqYg8LyK2bnYKqPMpGTZLrDHtUrNXroh4gPuAs4Bi4CIRKW6U7Apgl6oWAXcDd7jHFgOTgOHAeOB+EfE0k+fPVHWkqh4FbASmtvIcTRKo8/nJ8Eiii2GMOQjRfMUbA5Sp6jpVrQVmABMbpZkIPO5uPw+cISLi7p+hqjWquh4oc/MLm6eq7gFwj88BtDUnaJKD16+kW6Awpl2KJlD0BjYFPS5394VMo6peYDfQLcKxEfMUkX8AW4FhwL2hCiUiV4vIAhFZUFFREcVpmERRVXx+JT3Nmp6MaY+iuXJDfQ1s/C0/XJqW7nc2VC8DDgdWAReGKpSqPqSqJapaUlBQECqJSRJ1Pudfa01PxrRP0QSKcqBv0OM+wOZwaUQkHcgHdkY4ttk8VdUHPAd8K4oymiRW53MWK0q3zmxj2qVortz5wGARKRSRTJzO6dJGaUqBye72+cBsdda6LAUmuaOiCoHBwLxweYqjCOr7KM4FVrfuFE2ied0aRXqa1SiMaY+anWZcVb0iMhWYBXiAR1V1hYjcBixQ1VLgEeBJESnDqUlMco9dISIzgZWAF5ji1hQIk2ca8LiIdMJpnloCXBPbUzbxVud3ahQ2PNaY9imq9ShU9XXg9Ub7bg7argYuCHPsdGB6lHn6gROiKZNpP7z1fRQWKIxpj+zKNW3uQB+FNT0Z0x5ZoDBtzuu3UU/GtGcWKEyb8wZqFHYfhTHtkq2ZbWLO51funb2WhRt2MbRnHv3ddbGtRmFM+2SBwsTc03M38Of/rGVwj47MXb+TWq9To+iQaW83Y9oju3JNzL246HOO7J1P6dQT2FfjZfbqbazZupcxhV0TXTRjzEGwQGFiqrrOx9LyL7nm1EGICHnZGUw8uvHUYMaY9sR6F01Mle+qwq9Q1MOWETEmVVigMDG1aVclAH27dEhwSYwxsWKBwsTUtj3VAPTKz05wSYwxsWKBwsTU3movAHnZGQkuiTEmVixQmJjaV+MEio5ZNk7CmFRhgcLE1P4aLzkZHjw2pbgxKcMChYmpfTVeOmZbbcKYVGKBwsTUvhqfNTsZk2IsUJiYqqr1kZVubytjUold0SamfH6/LVBkTIqxK9rElNevtkCRMSnGAoWJKZ9fSbcRT8aklKgChYiMF5E1IlImItNCPJ8lIs+5z88VkQFBz93g7l8jIuOay1NEnnb3LxeRR0XE7txqR7x+taGxxqSYZgOFiHiA+4CzgGLgIhEpbpTsCmCXqhYBdwN3uMcWA5OA4cB44H4R8TST59PAMOBIIAe4slVnaOLK6/PbSnbGpJhorugxQJmqrlPVWmAGMLFRmonA4+7288AZIiLu/hmqWqOq64EyN7+wearq6+oC5gF9WneKJp58VqMwJuVEEyh6A5uCHpe7+0KmUVUvsBvoFuHYZvN0m5y+C7wZqlAicrWILBCRBRUVFVGchokHr19tyVNjUkw0gSLUVa9Rpmnp/mD3A/9T1fdCFUpVH1LVElUtKSgoCJXEJIDVKIxJPdHcQlsO9A163AfYHCZNuYikA/nAzmaODZuniPwGKAC+H0X5TBLx+tX6KIxJMdFc0fOBwSJSKCKZOJ3TpY3SlAKT3e3zgdluH0MpMMkdFVUIDMbpdwibp4hcCYwDLlJVf+tOz8Sb1+e3GoUxKabZGoWqekVkKjAL8ACPquoKEbkNWKCqpcAjwJMiUoZTk5jkHrtCRGYCKwEvMEVVfQCh8nT/5IPABuAjpz+cF1X1tpidsWlTXruPwpiUE9Xsbar6OvB6o303B21XAxeEOXY6MD2aPN39NqNcO+azO7ONSTnWmGxiyrnhzt5WxqQSu6JNTNkUHsakHgsUJqbqrDPbmJRjgcLElNUojEk9FihMTDnTjNvbyphUYle0iSmrURiTeixQmJhRVZvCw5gUZIHCxIzX70zXZTUKY1KLBQoTM75AoLA+CmNSil3RJmasRmFMarJAYWLG53MChfVRGJNaLFCYmPH6ncl+ba4nY1KLBQoTM4GmJ6tRGJNaLFCYmLE+CmNSkwUKEzOBPgpb4c6Y1GJXtImZOuujMCYlWaAwMVN/H4XVKIxJKXZFm5jx2vBYY1KSBQoTM/XDYy1QGJNSogoUIjJeRNaISJmITAvxfJaIPOc+P1dEBgQ9d4O7f42IjGsuTxGZ6u5TEeneutMz8VQ/6sn6KIxJKc0GChHxAPcBZwHFwEUiUtwo2RXALlUtAu4G7nCPLQYmAcOB8cD9IuJpJs8PgK8CG1p5bibO6ryBGoVVVI1JJelRpBkDlKnqOgARmQFMBFYGpZkI3OJuPw/8VUTE3T9DVWuA9SJS5uZHuDxV9WN3X2vOKyo3vrSMuet3oup8E9bAE0rDx9Akjdan0YaPgw9q4bGh0tA4/0Z5hsw3lufT4EQipwl0ZudlR/O2Msa0F9Fc0b2BTUGPy4Fjw6VRVa+I7Aa6ufvnNDq2t7vdXJ4RicjVwNUA/fr1a8mh9Q7vnMPQnnluhg1+1Qeq4HAlzaWpf14iHNMwTf3jBnGx0XPNHBuqTE3/fqRjYnc+g3t25Mje+RhjUkc0gSLUV/vG35vDpQm3P1TbRIjv4uGp6kPAQwAlJSUtOjZgymlFB3OYMcYcUqJpTC4H+gY97gNsDpdGRNKBfGBnhGOjydMYY0wSiCZQzAcGi0ihiGTidE6XNkpTCkx2t88HZqvTCF4KTHJHRRUCg4F5UeZpjDEmCTQbKFTVC0wFZgGrgJmqukJEbhORCW6yR4Bubmf1z4Fp7rErgJk4Hd9vAlNU1RcuTwAR+bGIlOPUMpaKyN9jd7rGGGNaSjTUMJ12pqSkRBcsWJDoYhhjTLsiIgtVtaS5dDbg3RhjTEQWKIwxxkRkgcIYY0xEFiiMMcZElBKd2SJSwcHPDdUd2B7D4sSKlatlrFwtY+VqmVQtV39VLWguUUoEitYQkQXR9PrHm5WrZaxcLWPlaplDvVzW9GSMMSYiCxTGGGMiskDhTiyYhKxcLWPlahkrV8sc0uU65PsojDHGRGY1CmOMMRFZoDDGGBPRIR0oRGS8iKwRkTIRmRbHv9tXRN4RkVUiskJEfuLuv0VEPheRxe7P14OOucEt5xoRGdfG5ftMRJa5ZVjg7usqIm+JyFr3dxd3v4jIPW7ZlorIMW1QnqFBr8liEdkjIj9N1OslIo+KyDYRWR60r8Wvj4hMdtOvFZHJof5WDMr1RxFZ7f7tl0Sks7t/gIhUBb12DwYdM9r9/5e5ZW/VusRhytXi/12sr9cw5XouqEyfichid388X69wnw+Je4+p6iH5A3iAT4GBQCawBCiO098+DDjG3c4DPgGKcdYd/0WI9MVu+bKAQrfcnjYs32dA90b77gSmudvTgDvc7a8Db+CsZjgWmBuH/9tWoH+iXi/gZOAYYPnBvj5AV2Cd+7uLu92lDcp1JpDubt8RVK4Bweka5TMPOM4t8xvAWW1Qrhb979rieg1VrkbP/wm4OQGvV7jPh4S9xw7lGsUYoExV16lqLTADmBiPP6yqW1R1kbu9F2dNjt4RDpkIzFDVGlVdD5ThlD+eJgKPu9uPA98I2v+EOuYAnUXksDYsxxnAp6oa6U78Nn29VPV/OCs4Nv6bLXl9xgFvqepOVd0FvAWMj3W5VPXf6qz/As769X0i5eGWrZOqfqTOp80TQecSs3JFEO5/F/PrNVK53FrBt4FnI+XRRq9XuM+HhL3HDuVA0RvYFPS4nMgf1m1CRAYAo4C57q6pbvXx0UDVkviXVYF/i8hCEbna3ddTVbeA80YGeiSobJNoePEmw+sFLX99ElHGy3G+eQYUisjHIvJfETnJ3dfbLUs8ytWS/128X6+TgC9UdW3Qvri/Xo0+HxL2HjuUA0WodsS4jhUWkY7AC8BPVXUP8AAwCDga2IJT9YX4l/UEVT0GOAuYIiInR0gbt7KJs2zuBOCf7q5keb0iCVeWuJZRRG4EvMDT7q4tQD9VHYWzKuUzItIpjuVq6f8u3v/Ti2j4hSTur1eIz4ewScOUIWZlO5QDRTnQN+hxH2BzvP64iGTgvAmeVtUXAVT1C3WWivUDD3OguSSuZVXVze7vbcBLbjm+CDQpub+3JaBsZwGLVPULt3xJ8Xq5Wvr6xK2MbifmOcDFbvMIbtPODnd7IU77/xC3XMHNU21SroP438Xz9UoHvgk8F1TeuL5eoT4fSOB77FAOFPOBwSJS6H5TnQSUxuMPu+2fjwCrVPWuoP3BbfvnAYHRGKXAJBHJEpFCYDBOB1pblC1XRPIC2zidocvdMgRGTUwGXgkq26XuyIuxwO5A9bgNNPiWlwyvV5CWvj6zgDNFpIvb7HKmuy+mRGQ8cD0wQVUrg/YXiIjH3R6I8xqtc8u2V0TGuu/TS4POJZblaun/Lp7X61eB1apa36QUz9cr3OcDiXyPtaZ3vr3/4IwW+ATn28GNcfy7J+JUAZcCi92frwNPAsvc/aXAYUHH3OiWcw2tHFXRTNkG4owoWQKsCLwuQDfgbWCt+7uru1+A+9yyLQNK2qhcHYAdQH7QvoS8XjjBagtQh/Ot7YqDeX1w+gzK3J/L2qhcZTjt1IH32YNu2m+5/98lwCLg3KB8SnA+uD8F/oo7g0OMy9Xi/12sr9dQ5XL3Pwb8oFHaeL5e4T4fEvYesyk8jDHGRHQoNz0ZY4yJggUKY4wxEVmgMMYYE5EFCmOMMRFZoDDGGBORBQpjjDERWaAwxhgTkQUKY2JAnPUKVovI30VkuYg8LSJfFZEP3LUAxojIKXJgPYOPA3fAG5Ps7IY7Y2LAneWzDGemzxU4U04swbkLeQJwGc6aCrer6gfuhG/VemAKcGOSltUojImd9aq6TJ2J7lYAb6vzTWwZzsI3HwB3iciPgc4WJEx7YYHCmNipCdr2Bz3246wydztwJZADzBGRYXEunzEHJT3RBTDmUCEig1R1GbBMRI4DhgGrE1wsY5plNQpj4uenbkf3EqCKhqvNGZO0rDPbGGNMRFajMMYYE5EFCmOMMRFZoDDGGBORBQpjjDERWaAwxhgTkQUKY4wxEVmgMMYYE9H/A06fytXe2w3FAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEWCAYAAABrDZDcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJztvXl83FW9//98T9amTdImTdd03+hCN0opm0UFyiqCV0RFURRcv1e9ylcU1+8Vf1636wW9KAoKXFDxAoKCUkDK3kJbW7pRmrZpmzZt06RJmj0zc35/zGcmk2TmM5/Zt/fz8cgjM585n3Pec2bm/TrnfTYxxqAoiqLkL650G6AoiqKkFxUCRVGUPEeFQFEUJc9RIVAURclzVAgURVHyHBUCRVGUPEeFQFEUJc9RIVAURclzVAgURVHyHBUCRYkBEblVRP53yLX/EpE70mWTosSK6BYTihI9IjIN2AVMMMa0i0gB0ABcbYxZn17rFCU6tEegKDFgjDkAbAbea116F9ClIqBkIyoEihI7DwEftB5/yHquKFmHhoYUJUZEpAY4CMwBtgNnG2N2pdcqRYkeFQJFiQMR+RtQCIw1xixLtz2KEgsaGlKU+HgIuBANCylZjPYIFEVR8hztESiKouQ5KgSKoih5jgqBoihKnqNCoCiKkucUptsAJ4wdO9ZMnz493WYoiqJkFZs2bTphjKmJlC4rhGD69Ols3Lgx3WYoiqJkFSJywEk6DQ0piqLkOSoEiqIoeY4KgaIoSp6TFWMEiqLkJv39/TQ0NNDT05NuU7Ka0tJSamtrKSoqiul+FQJFUdJGQ0MD5eXlTJ8+HRFJtzlZiTGG5uZmGhoamDFjRkx5aGhIUZS00dPTQ3V1tYpAHIgI1dXVcfWqVAgURUkrKgLxE28dqhAoUVF3/BQb9jWn2wxFURKICoESFRf+9EU+cLcey6soAPX19SxatCiqe375y19y//33R5XXfffdx5w5c5gzZw733XdfTLbaoYPFSkL4w+sH2XKolR+8b/Gw19btPs6qmdWUFhWkwTJFySw+/elPR5W+paWF7373u2zcuBER4YwzzuA973kPY8aMSZhN2iNQEsKtj27jD28cGnZ9V2M7H/vtG3z78R3DXjPGMP3WJ/nJ2t0xl/u3bY00neoN+3qv20NjW3fM+Su5TX19PfPnz+emm25i4cKFXHzxxXR3+74vW7ZsYdWqVSxevJirr76akydPArBp0yaWLFnC2WefzS9+8YtAXh6Ph1tuuYUzzzyTxYsX86tf/Spkmd/5znf48Y9/bJtXME8//TQXXXQRVVVVjBkzhosuuoi///3viawG7REoyaWtux+A/c2dYdPc+Y86vnzxvGHXe/o93LVuL5995yxKCof3Jtp7+vnMg5tZOKmCJ//1/JB5f/nhrfz1zUb23H4pRQXZ0e55pe4E9c2dfPisaXHl4/Ua2rr7GTOy2DbdweYuplaXxVVWIvjuX3aw80h7QvNcMKmCb1+50DbNnj17+P3vf8+vf/1rrr32Wh555BGuv/56PvrRj3LnnXeyevVqvvWtb/Hd736Xn/3sZ3z84x8PXL/lllsC+dxzzz1UVlbyxhtv0Nvby7nnnsvFF19sO6UzXF7BHD58mClTpgSe19bWcvjw4Shrwp7s+GUo2U8MJ6Le8/J+/uu5PfzulfqQr3s8vkwPt4Zv8T+z85gvrTe8AW1d/bR09tnaUne8gwM2Ygbw6OYGnt5x1DbN1x/bxucf2myb5sO/2cBtj223TWOMwe3x2qb5+fN1LPv3ZzjWHn5a4V+2HuEdP3qedbuP2+bV2tVHIo61XbvjKBvrW+LOJ5HMmDGDpUuXAnDGGWdQX19PW1sbra2trF69GoAbbriBF198cdj1j3zkI4F81q5dy/3338/SpUs566yzaG5uZs+ePWHLtcsrmFD1nuiZVtojUJJKPF/Xnn4PAL1ue4cXr39a8v/WAlD/g8vDprnwpy9ETPNvD2+NmOahDQcB+PmHojZzEF9/bDu/f/2gbVlrd/pE6Xh7L+MrSkOm2Xa4DYDdR09xwbxxIdM0nOzivP94nq9dehqfWj0rbHn3vryfs2dVM39iRdg0Nz+wCQhdR5Fa7smipKQk8LigoCAQGgqFMSasEzbGcOedd7JmzZpB12+77TaefPJJwBducpJXMLW1taxbty7wvKGhgQsuuCDifdGgPQIl4wnn6KNpFCWgMZtR/P71gwnNz656Gk76HONzb9n3Gv7fX3dy6X+9lECr0kdlZSVjxozhpZd87+eBBx5g9erVjB49msrKSl5++WUAHnzwwcA9a9as4a677qK/3xcOffvtt+ns7OT2229ny5Ytg0QAsM0rmDVr1rB27VpOnjzJyZMnWbt27TCxiRftESgpwcQQG0pE51fXKtnXvVZPeO677z4+/elP09XVxcyZM/ntb38LwG9/+1tuvPFGysrKBjnkT37yk9TX17N8+XKMMdTU1PDnP//ZtoxweQVTVVXFN7/5Tc4880wAvvWtb1FVVZWgd+lDhUBJKqlYNeokdh2LEGU7kmg3n4NVOH36dLZvHxiP+cpXvhJ4vHTpUtavH75m5owzzmDr1q2B59/5zncAcLlcfP/73+f73/++bZn+9HZ5DeXGG2/kxhtvtM03HjQ0pKSEeEIz4Zy4E0eXcGeYhTipe7s0WoO5jwqBklTi6hBEuDkfW/nR4Kju1csrJFkIRGSKiDwvIrtEZIeIfMG6XiUiz4jIHut/4pbIKRlFXIO0uTbCmyac1KITUU2W8CZiWmq+E28dJrtH4Aa+bIyZD6wCPiciC4BbgeeMMXOA56znSp4R7+9fwz7xk+46LC0tpbm5WcUgDvznEZSWhp4i7ISkDhYbYxqBRuvxKRHZBUwGrgIusJLdB6wDvppMW5T0kMzQkB91IfbY1WK6w2u1tbU0NDTQ1NSUVjuyHf8JZbGSsllDIjIdWAZsAMZbIoExplFEhq1kEZGbgZsBpk6dmiozlWwij9cRREO8bz2ZM7+KiopiPlVLSRwpGSwWkVHAI8AXjTGONhMxxtxtjFlhjFlRU1OTXAOVpJOuoYJ8XkfgbKw4jytICZB0IRCRInwi8KAx5lHr8jERmWi9PhGwX7KoZC1xRYacJnQyPTIOO7IdR+ss4pxiqmQ3yZ41JMA9wC5jzE+DXnoCuMF6fAPweDLtUNJPPIOB8fifvG7vOugOOekx5XOvKl9I9hjBucBHgG0i4t9o4+vAD4CHReQTwEHg/Um2Q0kTKXEi6qiSivYEcp9kzxp6mfA/03cns2wlM0iEE4no5/PYUTnZwdKuelRDFdCVxUoWEM6RacjCnkRVj9Zz7qNCoCSVeJyI03vzuEOQsLCNLujKb1QIlJQQys3EPb89mvLV0cWN1mDuokKgJJkExBXicOKp2AY719EazH1UCJSMxelip3xu7TvaUM5ui2kHVZy/tZs/qBAoKSHdvjofnZl2hhSnqBAoSSUVzsgu/KO+EJzIoB5Mk9+oECgpIZkt8kRtoZCN2L133WtIcYoKgZLxhF9HoE4sUTgba8hRNVVUCJTUEIvLTuQ6glzVjPi3mE5MGiW7USFQUkK625LamLXH0e6jyTdDSRMqBEpSsT0dy6F3jsuJa2tWRVCJiAqBkhqS4I00Zh1pjYBzFXQUInKcm5JtqBAoSSURA7oJiVGrZtiioaH8RoVAyXjiOqoycWZkLfFvQ621mOuoECgpIRZf7tT9OGvN5mZ71u59RbUpX47Wj+IMFQIlqSQmqqNOKh5shTKKuJsOyeQuKgRKUolrwo/jdQSRS8nVFbTxbijnJB8l91EhUPKCfOxVOHHu0cijLizLXVQIlKSSTN/hbEWxeq9Eob2G3EWFQEkJ6kRST6I0ULU091EhUJKKnRNJpTbksxDpwjslEioESsYTyY8lasA014hmgNzR7qOxm6JkOGkTAhG5RER2i0idiNyaLjuU1BDLYG0i4/u56sTibezr1hIKpEkIRKQA+AVwKbAA+KCILEiHLUpyydVpm9lEroqgkjjS1SNYCdQZY/YZY/qAPwBXpckWJcOJ5Mjy2dHZ9rSiWlqcz7WopEsIJgOHgp43WNcCiMjNIrJRRDY2NTWl1Dgl99AB09Akqsem9ZvdpEsIQn37Bn2TjDF3G2NWGGNW1NTUpMgsJZtI9IKpfMaRG1dnn7OkSwgagClBz2uBI2myRUkB6kOSQ0oGi/N56lWekC4heAOYIyIzRKQYuA54Ik22KEkkU3xIPuuQo91Z87mCFArTUagxxi0inweeBgqAe40xO9Jhi5Ia4nE0Ee9N0ClduUb+vnMlWtIiBADGmKeAp9JVvpJ+Ijn4PPbhjnG2EMzB7qxa13mNrixW8oJ8DH3oNtSKU1QIlJSQTD+Tj1tM+4l32qZfK5zUoV0KFZLsRoVAyV6icD65JhaJ3lnUdr+mxBSlZDAqBErGE8mJ2y2KCrySWzqQMPyD6Vo9+Y0KgZJU4mm5Ol31anuAe443Z50tBEtQWaoWOYsKgZIX5KMPi2ob6nysICWACoGSEuIa1IzjPAJ/cEgdXWgCYwR5KZWKHxUCJanEs6nZgJOKo/wcd3SOVg3bvObk88n18JqiQqCkkVQ458D0yBzTASeD4FE5cEeCEj5RjlVv3qFCoGQ9ti3eBPQqMpGB2T4O5v/HKRai4bWcR4VASSpO5qmHvRf/vaFvztVwjxOc9HSiCYs5EtP8re6cR4VASSpxTR916ICcFJFrB6c46ek4iv9b/3OtfpToUCFQUkJMh9fjbLGTE2eYq37OiQN31GuIc9BZyW5UCJSkEo8jduqk7Jxhrs54cSKS0fQanIWGVApyFRUCJakkYrA2Um/C3tFZaXLNh0W1s2hkobTfayhH1VQJoEKgJJVUxKDtQx/OZ9dkI87ee3w4EQvtLWQ3KgRKUsmU0Eyu+Skn20cnqupzfVGeokKgpIhYXEigRRvm5lxz7tEgA0oQmTgXi+X6gLuiQqAkmOEhgvCDBImYFuqUXPVhzgaL7cYI1MkrKgRKgkmkQ0nEbJVsnvFiO8jroJXuREgzJHKnpBkVAiWhhPNLMYWG4rg3kEcWbzGRsFXDjtYROJhZFLEkJVtRIVASStjtIGJokScibJGr8W1nW0wkttdg9xnmWPXmHSoESkpIv6NIvwXRYh//d7AQzEE+TsqKJo2SnSRNCETkRyLyloi8KSKPicjooNe+JiJ1IrJbRNYkywYl9WSas8iU6auxYD9G4CCNo7BPFD2mTPtwlYSRzB7BM8AiY8xi4G3gawAisgC4DlgIXAL8t4gUJNEOJYUkcqpnpDh4NFlmY2gofpOj2YZCwz75TNKEwBiz1hjjtp6uB2qtx1cBfzDG9Bpj9gN1wMpk2aGklvBOO5ZN56x74xoj8JeffTjaCC7ODeUSfHaNkqWkaozgRuBv1uPJwKGg1xqsa4MQkZtFZKOIbGxqakqBiUoiSOjirwRtkRBz+WnGVjwdHSgzkFMiyMYpuIozCuO5WUSeBSaEeOk2Y8zjVprbADfwoP+2EOmHfcOMMXcDdwOsWLFCv4FZTnwH08Rebq7uNRTNwTRO0G2o85u4hMAYc6Hd6yJyA3AF8G4z0JxoAKYEJasFjsRjh5J6jDEBJxshZcxlDGQfRx7+HLLQiyVqMz3b9x5Fr8t+0zkHGSgZSzJnDV0CfBV4jzGmK+ilJ4DrRKRERGYAc4DXk2WHkhx0/5/0Es320YnapjvXelXKAHH1CCLwc6AEeMZqvaw3xnzaGLNDRB4GduILGX3OGONJoh1KEgi/gjhxC8oSSTYKlJNBXmcHykROo4Gf/CZpQmCMmW3z2u3A7ckqW0k+Psc+PDQUjcONvOlcAlYFZ/EWys7CPk62hohvz6JsFFElOnRlsRIT0e4pFMekIZswVORcc3+MwCaNk8PrEzygrGQnKgRKTETrnOOaNRTXgHMWLy22Iar5/3GuR4gmjZKdqBAoMRHtat+YFpQ5PLzeNg9/+VnoxOKdyWNzFMTQJEqeo0KgxES0jjVU+kji4GTWi+Pys3GMwEH83652ojkvOt7xiGysX2UAFQIloYQNGaXWjADZHBmKJJPgbBzBNpcoel3q6nMXFQIlJsI6jiHXMyUkkyl2RIOzg2niw8mAsrb2cx8VAiUmErm5XFgSMkaQuPBSyol30zkHaaIoKivFVHGGCoESE9GuLA45RhBxHYGVLiHbUOeWF3Myo8rRcZZRhYZyqw6VAVQIlJiIfr1ALLOG4o9/ZPN5u46cfJw9gmim6OaYlipBqBAoMRFtCzu+dQTxk41OzNE+Qk4WnTkZUM7C+lEShwqBEhNhewThFpRFkYefbJ7xkwic7CNkh6P9iBykcWJPNgqtMoAKgRIT0U4TTX+MPt3lR0/c8/8dnFnszI64bleyABUCJTaiHSyOp6g4PFE0h7OnX6wGE+9MHidTQ6Mhw6pHSSAqBEpMOJ0+GtfGoQkIX0cV+sgiR5eos4Ylql5DFlWQEhUqBEpiicJXRHI+kQZEnfiubF45G/9AsD+jyGlyTSiV6FAhUGIi+jGC6MtI5IQWR/H2DPN0jqZ0OtlrKM7zCAbKUnIVFQIlJqJ1CvE42fjGCGK+Nak4ek9OWvKJShPZmowTSiVxqBAoMRHtuQOxuJBEniWQaRHweFvgThx4wgeLE5qbkkmoECgxEX5lsXMlSIVjiSr0kUJPl6gZQc6mmDopy2ZNuCpAzqNCoMRE1HsNxVNWHPcO5BHnnPwEk6gwi7MZQXZpnG/Kp4KQu6gQKDER9QllMXgRB2evRM4jivmjGdcjiFOYnB1eH4VBSs6iQqDERtgeQRRbTERwPo52z4xAIvcrSjXxDgQ7ObwmOnuysRYVJ6gQKDHh1CUk5CyBsOEm5wsJMs2HxT1Y7CiVlTZBY8YZVoVKAkm6EIjIV0TEiMhY67mIyB0iUicib4rI8mTboCQep2MEfmcdiy9KxOH10ZDa0FB86xqi2TrDEU4+IJuyMk1olehIqhCIyBTgIuBg0OVLgTnW383AXcm0QUkO0YZrYpo+GsM94cvPtMHi+NKkcusMf73YZaOH1mQ3ye4R/Cfwfxn8HboKuN/4WA+MFpGJSbZDSTCOewT23sNZWYkYI8iwweJE4WiLiQSVkaFr85QEkDQhEJH3AIeNMVuHvDQZOBT0vMG6NvT+m0Vko4hsbGpqSpaZSow4XUeQCOcaz8KoTD13JeMGcOMcs8hGEVUGKIznZhF5FpgQ4qXbgK8DF4e6LcS1YV8jY8zdwN0AK1as0K9ZhuF0ZXG6QwYDPYLELLxKFIk6GjJem3UgWYE4hcAYc2Go6yJyOjAD2GoNatUCm0VkJb4ewJSg5LXAkXjsUFJPKjadS6RzybS9dOI+LD5Bu6omKmSmU0uzm6SEhowx24wx44wx040x0/E5/+XGmKPAE8BHrdlDq4A2Y0xjMuxQ0o+df4jUKo7oWxzNHnXe5M00Vxbv+EpUE4FsEjsbaFeymbh6BDHyFHAZUAd0AR9Pgw1KnIQfLA79QiwhiIhCEV1mkZNk3MpiJ2niMzrwecU5NVQ7BNlNSoTA6hX4Hxvgc6koV0keTreYiMdBRLrX6yBzJ3vyp4NUDvKmpIjMql4lSnRlsRIT0S4oi6kM63+43kQ0vjTTTmJM1JiFMyedmF6DXacu04RWiQ4VAiUmwv/snc0mCndt8Ovxh4aiO6oyMc7M2WloDvJxVJaDRA7ut3vvqbBDSS8qBEpMOJ4+mkQH4fU6CQ2lfpvlRPU+EiZeNgM0mTKNVUkvKgRKTDj94cfjIFLdynQy5pCwg2Di3GtoII2Dwhzg9TpIo83+nEWFQIkJp+sIbE++ilSGf4+bMAkdOW4rDydpPQ7SOOiEOHLgTvKxs8ffyLd7XwNhMZvPwETOh0Ad2qRQkchqVAiUGHE+FhAOpy3MsDOUHM2l93lDJ2GkRLWKnQiKx4E9dmlclpe3s6dAIr/3ASEIb0eixhGUzEWFQIkJp2cE2DmISE414mCy/cs+rFaxI+ecIAeeKEGxy8cvBB6bNBIQi/Bp/C856bk5EQslO1EhUGIi3O8+msHiyLOG7NNFE7N2Eopx1GtwFPZJUI/AQdgn3l6DXwDs0wxOGzKN9gmyGhUCJSbCOY7hl604fwhHEckZRmqJRhWGSpCTj9eBR5VPnE7e5UAsAmU5iP/bZqM6kNWoECgxEc65DHVMdjHoyKEhM+h/uNft8E+cjNfx+smUnoXL+uXa2TwwoBy+DGet/chlqQ5kNyoESkyEi18P9Sd+5xFy7/EI3iOiUNjfPtiOBIV0nDj5hImOo0He8Gm8DtL0Wx+ky2atgd9Wl83S4n67wQol41EhUGIinGMdet0dcCLDvUgkZ9hvxStcYTyQo1lDDqZQ+ol3Smc0aeKdfeS31a4O/WXYpXF7nDt5O7Fw28WWlIxHhUCJiXDOZeh1vxMpCOFpIjnDAQdk/7oTnCSNt5U+kCYx9tjlYxw4eeNALJw4+UiCDOB28Kad1K+SHlQIlJgIP1g8pEdgOZFQfsYdwTH47w0lIgC97iiEIJUDwSkoy1//dmLqd872afyfj11r316QYUAs7NDwUeaiQqDEhNMegdsmBt3T77Etwx+/Duek+hwIgT9NPAO4weIW7n0Hp0nYYLFt2MdvT/j7/UJqHxpy4OSt+wviDA0FC7+TOlJShwqBEhPhfshDL/fZtOp7+u0deaBHEMYB9brthcSXJnKr2E843xRsZ7hsgnsniRosduLA7XoNfqG1S9Nn02Pz0++OHD7q80T+LPqD60hXoGUUKgRKTIT7IQ91uL2WMyoMKQT2zqOzz237ejQ9grDTXb2RW/sdve6IaTqD0oQTnWDhinf6aGefLy+7lvWpHreDNP1WWeHt8KcpKymIWJYdwWl0A7vMQoVAiQmnoSH/j39UyfDD8CIJQXu3795wotPW3R/Rzh7L+YZzPF39kZ1zV5AghbOlw4EQdPZGLmtQiMnGWXZZ5dn1Gvx1bxc+8texnVi0W/mMLA5/oKGTz6K9ZyCNkwF1JXWoECiOCXYWwU7Kznm127QmWyM4D/+94aZ+nuzq8+VdHL6lerLTvsXb3NEbeBzOqbZ09gUeh3OYrV0D7yWc423t6ouYZnDvI3QaY8xAj8BGLPzO2T6Nzya7UE3gvdmEj5wIwaA60h5BRqFCoDimoy+0kwqOoQ91OnYhg6ZTPidcXBD6a9jSYTmpsA7aEpkwQuDxmoBjDZfHsfYBIQjn5BvbegbyDOPAjrR2Dyo3dJqeiGkOB+fjoCdkN3jdcLLLNo2vvB4HaXz52PUagu0OJ9x+e0BDQ5mGCoHimLau0A7I79B91wffc6y9J+R1gBNWa7ykMPTXsKHV78hC23Ooxd7RNbYNOKdwTizYgYfzc06c/OFB+cTuCBtaItt8qCWyWJzs6g/0GsKlMcYE6tDOLx+0yrNrxR9sHnhv4eroQEvQ+9dZQxmFCoHimKagMEqwI7Nzgg0nfa+FaiUesnEwbo830IIO5zT3NnX47g/jVPYc6wg8DufEdh1tj5hmZ+NAmnC+cFfjqYF8wtizKyifcGl2OkgTnE84h7prkM3hBSVSj6mn38Pe4x1WWSGTAPDW0aD3H6a8t4LtVh3IKFQIFMf4nToMdhyDhMAbWghCOZo9x0+FfW1vU2fgeigh6HV72HeiEwjvnHc6cDw7j0R2qtsPtwUeh3OYWw6dpKjAOiMgjEFbDrVSWuSKmGZEUYFtms0HT1JeWmjZEzIJmw+cBHxhs3A2bz7oSzO6rChsWTuOtNHn8frShMmn6VQv+090UjWyGAgtGF6vYZNlk89uVYJMIqlCICL/R0R2i8gOEflh0PWviUid9dqaZNqgJI5DLaFDG/tPhG55n+zsC4R/hjqa7j4PB23CElsO+ZxG5YjQDmhbQxt9bi9Tq8rCOrHX9jYzd/woXBLayff0e3ijvoXlU0f7bAyR5lh7D28f62DljKqQ7wN8Iai9TZ2BNKHKaunsY/uRdlbNrA6bpqffw/p9zZw9y5cmVEveGMNLe05wlo09AC/uaWL+xArGlBWHFYsX3m6ickQRp00oDyuCL+xuwiWwcnpV+LLebgLgbOu9hUq3paGV9h73QB3pGEFGkTQhEJF3AlcBi40xC4EfW9cXANcBC4FLgP8WkfDTPpSMIVgIgp3mrsZTgXUCwf5k+xFfS3rsqOJhzn7LoVaMgdMmlId0HJsPtFJRWsismpEhncb6fc0ArJpZFdKB9/R7eL2+hfNm11DgkpBlbNjfQk+/l3fPH2/ZPjzNc7uOA3DxAitNiLLW7jgGwCWLJlr5DEvCszuP4fEaLrPShLL55T0n6OrzcOmiCVaa4flsbWjjcGs3lyyaGFbgjrX3sPHASS5dNAGXK/T76un38OzOY6xZOJ6iAlfI+jHG8NdtjayaWU1NeUlYsfjrm0eYPHoEy2wE9S9bj1Bc6BqoRxWCjCKZPYLPAD8wxvQCGGOOW9evAv5gjOk1xuwH6oCVSbRDSRC7GtupHTMCGPxj33mknYWTK4HBjmmbFVJZXDt6mHN4fX8LIrBqZnWIMwwMz+8+znlzxlLocoV0LGt3HmNxbSXVo0pCOpV/vHWcPreXd502DpdISCf2+JbDjCopDLTAQ+Xz+JbDTK8uY/7EimHv28+ftxxmzrhRzK4ZFTbNo/9sYErVCE6vrQxb1v9uamB0WRHnzRnryydEmkc3N1Bc4OKi+ePDCtyjmw9jDFx2+kQKRELa8/SOo5zqdXPF4kkUuELXz+aDrexr6gykCVXW0bYeXtpzgiuWTAysHh+aV0+/hye2HOGd82qoGFEUto6U9JFMIZgLnC8iG0TkBRE507o+GTgUlK7BujYIEblZRDaKyMampqYkmqk4od/jZdfRUyyZ4mv1+R3Z8VM9HG3v4fTJwx3l5gOtTK8uCxlf3rC/mfkTKhhdVoQxg8MgO460c/xUL+86bbzVoh1sy4HmTt5saOOKxeEd3aObGxhfUcLZs6p9jm7YtNZ+ntrWyJVLJgUWSg1tgdcdP8WG/S184MypA2cED8lnW0Mb/zzYygdXTh1whEPSvHW0nfX7WvjwWdMCaYaWdbi1m7U7j3LdmVMpKfR7BAI8AAAef0lEQVR1kIc61Laufv60sYH3LJ1EZVlRSIHr93i579V6zp1dzexxo3CFcODGGO55eT8zx47kvNljfXUYwsnf8/I+KkoLuWrpJFxh6vl3r9bjNYbrg9/bkLwe++dhmjv7uOGc6YHtQnRBWWYRlxCIyLMisj3E31VAITAGWAXcAjwsvt3DQp5RMuyCMXcbY1YYY1bU1NTEY6aSAPYc66DP7WVprb/777u+YV8LwEDs23ICbo+XDfuaOXuWz9EEO/r2nn7eqG/h3NnVA44h6BuwducxROCd82pCOru/vtkI+Fq8LpfgHSIkJzp6Wbe7ifcum0yBSywnNvj9PLH1CD39Xq5dUYt/GcNQB/bQhkMUFQjvX1Eb5MAHp7n/tXrKigv4lxW1FFqDxUN32bzv1QOUFLr4wIopgXyGbtv8wGsHALh+1dTAoPPQvZT+8MZBuvs93HjuDMC3/mLoDqxPbWvkaHsPnzjPl6asuIDuvsH5vFF/kjcb2rjxvBm4XEJJkWvYvk+HWrr4+/ajfOisaYwsKWSElU9wPXf0unlwwwEuPX0iU6rKAoPcXcErqL2G37y0j0WTKzh7ZnXgZDUNDWUWcQmBMeZCY8yiEH+P42vpP2p8vA54gbHW9SlB2dQCR+KxQ0k+/pkzZ1qDfd3W1gzr9zUzqqSQJbWDewpbG9o41evmvNljfY446Ie/bncT/R7DmoUTAnvc+x2sMYY///Mw58yqpnpUybCQhNdreHjjIVZOr6J2TFlgbCLYQT+04SBur+H9Z/i+ZsWFrsH7/HgN9768nwUTK1g6ZXSgBR685UVrVx9/fOMgl50+kbGjShhprYwO3ibiWHsPj289wjXLJ1NRWkS5tY1G8OrgY+09PLK5gWuWT2bMyOJAmuCFdic7+3jgtXouPX0itWPKGFlciEsGp+nu8/Drl/ZzzqxqFkzy9b4qRhQN2rbB4zX8/B91zKoZyQVzxwG+wfb2Iat+73huD1Uji3nf8lpfPqVFw1YG3/mPPRS6XHzsnOmBfNxeQ1eQqNz3aj2netzcfP7MQBoYvODtL28eYW9TJze/YxYiErZnpaSXZIaG/gy8C0BE5gLFwAngCeA6ESkRkRnAHOD1JNqhJIBth9sYVVLIQssJ+TciW7+vmZUzqiiymtX+rYZf3nMCEThnVrUvPBHU4Hx6x1HGjipm2dQxgdZvn5Vg44GTHGzp4pplPidVWjS4RftS3QkONHfx4VVTARhpOVa/g+51e7j/tQNcMK+G2eN8MfuK0sJBTvW5t46zt6mTT62eiYgE4tbBDvN3r9bT2efhMxfMsvKw0gQ53rvW7cXjNXzqHVaaQD7uQWm8XsNnVs8elCbYWf76pX109Xv4wrvnAL4DYCqGOPAH1tdzoqOXL100N3DNl2agrL9sPcKe4x186aK5AYGtKB0sFq/uPcHLdSf47AWzGGGtyK4cMVgI9jZ18L+bGrh+1TQmVJYG0gS//5Odffxy3V4unD8+EC4cmqbP7eUna9/mtAnlXHG6b5A83DiCkl6SKQT3AjNFZDvwB+AGq3ewA3gY2An8HficMSbyHrZKWtl2uI0FkyooKnBRVlzAqR43DSe72NvUyTmzqgN7Cfmd9gtvH2fRpErGjCxmRFEB3db2FD39Hta9dZyLFvgGO0eV+JxHh+WoH93cQFlxAZdYM2fKhzjxB9cfoHpkceD1Cms+vd/5/HVrIyc6egPhExjecv7VC3upHTOCyy3nVF5SiMjA5modvW5++0o9F84fz2kTBlrfMCAWx9t7+P3rB7lm2WSmVJVZtgx28kfbenjo9YO8b3ktU6t9aUqLCigudAXyaens475X67li8STmji8fsDmold7R6+audXs5f85YzpxeFUhTOaIwkE+/x8t/Pvs28ydWBGYmDc3HGMOPn97NhIpSrl81bVD99Lm9gc/up8+8TWlRAZ9956ygsnzvzb9f0C9f2EtHn5tb1swblE9wmj9uPMTBli6+eslpAWFyhQgFKuknaUJgjOkzxlxvhYqWG2P+EfTa7caYWcaYecaYvyXLBiUxuD1edjW2c7o1M6i8tJCOHjfP7PRNm7xw/vjAgGtHr5vj7T1sPtjKRdZUwfLSQjr7PHi8hnW7m+js87Bm4YCjB18Po6ffw1/fbOSSRRMCLf2K0qJA76OxrZtndx3j2jOnBMI5wS1sYwz3vrKfOeNGcb4188Zfhl9MNta3sPHASW46fyaFVi/G5RJGlQw41Yc2HKCtu5/PBTnCoWLxqxf34fYaPv+u2YE0pUUuigtcgc3l7lpXh3dIGoAxZUU0WxvZ/eqFvVZvYHCaqpHFHLe27rj35f2c7OrnyxfPG5Rm7KgSjlpbeDy88RAHmrv4clBvAGB8ZSlNp3rp6ffwzM5jbD7Yyv9592xKiwZmbE8a7Wv1N5zsYuuhVp58s5FPnjeDsaNKAmkmj/bNFjvY0sXh1m5+92o9Vy+bzLwJA+Lln1FW39xJe08/dzy3hzOnj+GCeQNjfIHQkCpBRqEri5WI1DV10Ov2BoRgTFkxJzp6+fv2o8wbX870sSMpcAllxQV09LhZu9M/r36ws+/odfPI5gZqyks4b7bPUY/yC0Gvmye2HOFUjzsQ2wff9tUdvW68XsPvXqkH4EMrpwZeD26Fr3u7iR1H2vnEeTMGnWrmtxfgP599m+qRxbx/Re2g91hTXkJjWzftPf3ctW4v580ey7KpYwKvu1zCpMoRHGzu5FBLFw+sP8B7l05mWvXIQBoRYWp1GXubOtnb1MGDGw7y/hVTAj0GPzPHjmLP8Q4ONHfy21fquWZZLbPHlQ9KM2fcKN4+1sGR1m7uWreXSxZOYKkVgvEzd3w5B1u6ONLazY+f3s3K6VW8e/64IWlG4TW+FcL//uROZo8bxbUrpgzLB3zrPr7x5+2MKy/hpnfMHGzP+FGI+GZ0ffvxHbhEhglTeWkRk0ePYPvhNn7y9G5OdPTyjcsXDPos/CurexwcKqSkjvAbjCuKxbYG30DxIksIZo0bxZPWzJ0vB8Ws/U77qW2NzBg7kjmBGL3PWR9s7uL5t47z8XOnB1rjo60WfUtHH797tZ5548tZNXMg/DG+shSvgbePn+J/1h/gisWTBjnWaVbIZZ8V1548egTXLB/s5GePG8WT2xpZu+Mor9Q1880rFlA2ZG/9eePL2XGknV88X8fJrn6+eslpw+ph7vhRvHm4je89uROXwJcvnjsszWkTynltbzO3PbaNEUUF/NtFw9MsnFTBva/s57MPbqaoQPjqJfOGpVk8ZTR/2tTA+3/5Gl5juO3y+cPSLLeE6rI7XuJUj5vvXrVw2LGeK6ZVIQLX3b2efo/hoZvOCoznDLyvcqpHFvOlP24F4M4PLqPc+sz8lBUXsnzqGO54bg8AX7/stEAvIZjV82p4aMNBAD52zvTA+IEff08veGaRkn60R6BEZPvhNkYWFzBzrK/1u2KazwEVuIQPrBxoXdaUl/Dq3mZe3dvMNcsmB5ySf8Dx//vbLtxeM6hFOnOsTyzufmkfOxvb+di50wc5s3lWa/Wm+zfS2efh06sHwjUAEytLGVNWxDcf38HWhja+cOEciofsZrps6hiMgZsf2MTUqjI+fNZUhnLOrGoOtnTxqxf2ce2K2sDCr2DeNX88+5o6eXrHMb7w7rlMCuEIr1wyiebOPtbva+Hrl8+nprxkWJprltdisFrXVy5kXEXp8HwWT6RqZDGHW7v596sWDetVAJw9q5qFkypo7ernG5fPDyx6C2ZCZSkfPmsqbq/hq5ecxjmzxg5LU1Tg4itr5lFeUsjn3jmLK5dMGpYG4JY185g8egQfPmsqnzxvZsg0n71gFsumjuaaZZP52mXDxdS/ZXik0+eU1KI9AiUi24+0s3BSZSD2fN2ZUznW3svKGWMYVz7gxBZMrOBPm3wrX689c8DZ+2cavbq3mXefNo45QYOilWVFzBtfzuv7W5gxdmRgSqOfJVMqqSkv4VBLNx86a2pg6qQfEeH6VdO48x91XDCvhn8Zcj/AebPHct7ssbx19BR3fnDZoPi4n/edUctLe05QVODiW1cuDFkP166o5VBLF5UjivjUO0I7wosXjOfH719CaZGLKxaHdqgLJlXw6GfOoc/t5Sxr/cVQRpcVs/ZL76Ctu59Z1orloRS4hMc+ey7Nnb1MrBwuSn6+997T+cblC0K+bz8fXDmVD64cLpDBrJpZzSu3vss2Te2YMh777LlhX/ePJXWpEGQUEm6L2kxixYoVZuPGjek2Iy/xeA2Lvv00162cwrfDOEg/uxrb+fLDW7l+1TQ+NKTV/ZO1u3m57gR3XLdsWOt288GT/M/6A3xm9axBIuHnraPtbDnYyjXLa4e19sE3G6bueAczxo4MhJxCYYwZFjpRUsvxUz2svP05vvfeRYNmLinJQUQ2GWNWREqnPQLFln1NHXT3ewIDxXbMn1jBU184P+RrX7543rDBRT/Lp44JxLtDcdqEisA0zlCISEgBCZVOSS/Bs8uUzEHHCBRb/BvHLXIgBIoSibLiAkYUFQw61U5JPyoEii3bD7dTWuQKG6dWlGgQESZUlgbWPyiZgQqBYsv2w20smFgR2BpAUeJlfEUJx1UIMgoVAiUsXq9hx5E2DQspCWV8hfYIMg0VAiUsh1u76ezz2A7UKkq0TBlTxpHWnmHbdSvpQ4VACYv/cPm543V8QEkcM8aOxOM1g44+VdKLCoESlreP+Q6lnzMu8tRMRXHKjBrfCvX9JzrTbIniR4VACcueYx2MKy+hsqwocmJFcYh/q5J9TSoEmYIKgRKWPcdPDdojX1ESweiyYsaUFbFPewQZgwqBEhKv17dtg/+UL0VJJLNqRrHn2Kl0m6FYqBAoITnc2k1Xn0d7BEpSWDCpgreOntIjKzMEFQIlJHVNvoFi7REoyWDBxAo6et0cOqkzhzIBFQIlJAes+O30scP3wVeUePFvJ77zSHuaLVFAhUAJw4GWLsqKC6gZNfxgFUWJl7njyylwCTsbVQgyARUCJSQHmruYWlWmWzcrSaG0qIBZNSPZbu1uq6QXFQIlJAeaOwPnAStKMlg2ZQz/PNSqA8YZgAqBMgzf8v9uplWPTLcpSg5zxvQxtHb1s9eamKCkj6QJgYgsFZH1IrJFRDaKyErruojIHSJSJyJvisjyZNmgxMbR9h76PF7tEShJ5czpVQC8UX8yzZYoyewR/BD4rjFmKfAt6znApcAc6+9m4K4k2qDEwIFm34yhaVXaI1CSx/TqMsaOKmZjfUu6Tcl7kikEBvDvX1wJHLEeXwXcb3ysB0aLyMRkGHC0rYfrf7OB5986nozsc5aDzb653dojUJKJiLBiWhUb9rdgjI4TpJNkCsEXgR+JyCHgx8DXrOuTgUNB6Rqsa4MQkZutkNLGpqammAyoGlnM5oMnWbvzaEz35yuHTnZR4BImVpam2xQlxzl3zlgOt3azVzegSytxCYGIPCsi20P8XQV8BviSMWYK8CXgHv9tIbIa1hwwxtxtjFlhjFlRU1MTk33FhS4uWTSBx7ccoa2rP6Y88pHG1h7Gl5dQWKBzCZTkcsFc32973W7ttaeTuH7pxpgLjTGLQvw9DtwAPGol/ROw0nrcAEwJyqaWgbBRwvnkeTPp6vPwPxsOJKuInONIWzcTR49ItxlKHjClqozZ40bxwtux9fqVxJDMJt8RYLX1+F3AHuvxE8BHrdlDq4A2Y0xjsoxYMKmC1XNr+PVL+2jv0V6BExrbejQspKSMC+bWsGFfC5297nSbkrckUwhuAn4iIluB7+ObIQTwFLAPqAN+DXw2iTYAcMuaebR29fPrF/clu6isxxhDY1sPk7RHoKSIixdOoM/j5dldx9JtSt6SNCEwxrxsjDnDGLPEGHOWMWaTdd0YYz5njJlljDndGLMxWTb4WTS5kssXT+Sel/fT2Nad7OKymubOPvrcXu0RKCljxbQxTKws5YktSYsQKxHIm9HAr645Da8xfPvxHek2JaNpbO0BYGKl9giU1OByCVcsnsiLe5po7epLtzl5Sd4IwdTqMr504VzW7jzGk28mbUgi6zli9ZgmjdYegZI6rlo6mX6P4XHtFaSFvBECgE+cN4PFtZXc+uibgdWzymCOtvl6BBM0NKSkkEWTK1lSW8n9r9Xr4rI0kFdCUFjg4hcfWo5LhM/8z2Y6dJbCMJo7ehGB6pF6DoGSWj569nT2NnXySl1zuk3JO/JKCMA3b/ln1y1l97FT3Hz/Rnr6Pek2KaM40dnHmLJiClx6DoGSWq5YMpHqkcX86sW96TYl78g7IQB457xx/OhfFvPq3mZuun8jp3R9QYCWjj6qRxan2wwlDykpLOBTq2fy0p4TvL5fN6JLJXkpBADXLK/lh5YYXPur9dSf0DEDgJbOPqpUCJQ08ZFV06kpL+HHT+/WsYIUkrdCAHDtiinc+7EzOXyyi8vueInfv34w709LaunyhYYUJR2MKC7gSxfO5fX6Fh7ZfDjd5uQNeS0EAKvn1vD3L76DxbWVfO3RbVz1i1d4pe5E3rZGet0eRhQXpNsMJY+57swpnDFtDN97cidNp3rTbU5ekPdCADBp9Age+uQq/vMDSzjR0cuHf7OBy+94mT++cTDvdi3t7fdSUqhfCyV9uFzCD645ne4+D//6+3/i9njTbVLOo794C5dLuHpZLc9/5QJ+cM3puL1evvrINlbc/gw33Ps6v3lpH282tOb8l7LP46VYhUBJM3PGl/P9q0/ntX3NfO/JXXnbQ08Vhek2INMoLSrgupVT+cCZU9ja0MbftjWyducxvvfkLgBKCl3MHjeKuePLmT1uFBMqSplYWcr4ylJqyksYVVyIK4unXva5tUegZAbvO6OWnY3t3PPyfkYUF/B/18xDJHt/W5mMCkEYRISlU0azdMpovnbZfI619/D6/hbebGjl7WMdrN/XzGP/HD6YJQKjSgqpKC2ivLSQUSWFFBe6fH8FLooKXZQU+J4XFbhwia8slwgi4BKsx0OeWzaJgIQ82ycx9PR7tEegZAzfuHw+XX0e7lq3l2PtPXz/6tMpLdIxrESjQuCQ8RWlXLlkElcumRS41t3n4Wh7D0fbejja3s2JU32c6umnvcdNe08/7d1uuvrc9Lm9dPT6/vd5vL7/bi/9Hi9e49v62RjwGoPB93/o9VRNZhKBOePKU1OYokRARLj9vYsYX1HCz57dw47D7fzwXxazZMrodJuWU0g2xN5WrFhhNm5M+m7VGY9fGJJNNoe2lNzlH28d4+uPbufYqR6uXDyJz79rNnPHa6PFDhHZZIxZETGdCoGiKNlCe08/v3i+jgdeO0BXn4dlU0dz1ZJJnDenhlk1I3UMYQgqBIqi5CwtnX3876ZDPLLpMLuPnQJgXHkJCydVMHdCOTPHjmR8RSnjK6xJHCWFlBS6EiIUHq+h3+Ol1+2l1+2htz/osdtrPffQ5/ZfD5+ux+2hp9//56W7z0N3/8C17n4Pp02o4L4bV0Y2LAROhUDHCBRFyTqqRhZz8ztmcdP5MznY0sUrdc28vr+Zt46e4pW6ZvpCTPN2CYwsLmREcQFFBb4JES6XbzKGf7KGMdDv8VrO3uDxenF7DG6vwe314vYmJjxbbE0YKSl0UVpUwIjiAkYU+f7KSwsZV14SuDZj7Mj4C4yACoGiKFmLiDCteiTTqkfyobOmAuD2eGls6+H4qR6OtffSdKqXzj43Xb0eOvvcdPd5cHuNb3KGNSnDa8BjDAUiFLqEwgKhwOWiqEAocAlFBS7ff5fvemGBUFpUQEnhgEMvKSygpCjocaGL0qKBx/7XiwtcGTcOp0KgKEpOUVjgYkpVGVOqytJtStagE8YVRVHyHBUCRVGUPEeFQFEUJc+JSwhE5P0iskNEvCKyYshrXxOROhHZLSJrgq5fYl2rE5Fb4ylfURRFiZ94ewTbgWuAF4MvisgC4DpgIXAJ8N8iUiAiBcAvgEuBBcAHrbSKoihKmohr1pAxZhcQapHGVcAfjDG9wH4RqQP8KyLqjDH7rPv+YKXdGY8diqIoSuwka4xgMnAo6HmDdS3c9WGIyM0islFENjY1NSXJTEVRFCVij0BEngUmhHjpNmPM4+FuC3HNEFp4Qq7TM8bcDdwNvi0mItmpKIqixEZEITDGXBhDvg3AlKDntcAR63G462HZtGnTCRE5EIMdfsYCJ+K4P1moXdGhdkWH2hUduWjXNCeJkrWy+AngIRH5KTAJmAO8jq+nMEdEZgCH8Q0ofyhSZsaYmniMEZGNTjZeSjVqV3SoXdGhdkVHPtsVlxCIyNXAnUAN8KSIbDHGrDHG7BCRh/ENAruBzxljPNY9nweeBgqAe40xO+J6B4qiKEpcxDtr6DHgsTCv3Q7cHuL6U8BT8ZSrKIqiJI58WVl8d7oNCIPaFR1qV3SoXdGRt3ZlxcE0iqIoSvLIlx6BoiiKEgYVAkVRlDwnp4UgnRvcicgUEXleRHZZG/N9wbr+HRE5LCJbrL/Lgu4JuVFfEmyrF5FtVvkbrWtVIvKMiOyx/o+xrouI3GHZ9aaILE+STfOC6mSLiLSLyBfTUV8icq+IHBeR7UHXoq4fEbnBSr9HRG5Ikl0/EpG3rLIfE5HR1vXpItIdVG+/DLrnDOvzr7Nsj+u4rDB2Rf25Jfr3GsauPwbZVC8iW6zrqayvcL4hfd8xY0xO/uGbnroXmAkUA1uBBSksfyKw3HpcDryNb6O97wBfCZF+gWVjCTDDsr0gSbbVA2OHXPshcKv1+FbgP6zHlwF/w7cGZBWwIUWf3VF8i2FSXl/AO4DlwPZY6weoAvZZ/8dYj8ckwa6LgULr8X8E2TU9ON2QfF4HzrZs/htwaRLsiupzS8bvNZRdQ17/CfCtNNRXON+Qtu9YLvcIVmJtcGeM6QP8G9ylBGNMozFms/X4FLCLMPsqWQQ26jPG7AeCN+pLBVcB91mP7wPeG3T9fuNjPTBaRCYm2ZZ3A3uNMXaryZNWX8aYF4GWEOVFUz9rgGeMMS3GmJPAM/h24k2oXcaYtcYYt/V0Pb7V+mGxbKswxrxmfN7k/qD3kjC7bAj3uSX892pnl9Wqvxb4vV0eSaqvcL4hbd+xXBYCxxvcJRsRmQ4sAzZYlz5vdfHu9Xf/SK29BlgrIptE5Gbr2nhjTCP4vqjAuDTY5ec6Bv9A011fEH39pKPebsTXcvQzQ0T+KSIviMj51rXJli2psCuazy3V9XU+cMwYsyfoWsrra4hvSNt3LJeFINzGd6k1QmQU8AjwRWNMO3AXMAtYCjTi655Cau091xizHN+5EJ8TkXfYpE1pPYpIMfAe4E/WpUyoLzvC2ZHqersN3yr+B61LjcBUY8wy4N/wbflSkUK7ov3cUv15fpDBjY2U11cI3xA2aRgbEmZbLguB3cZ3KUFEivB90A8aYx4FMMYcM8Z4jDFe4NcMhDNSZq8x5oj1/zi+leErgWP+kI/1/3iq7bK4FNhsjDlm2Zj2+rKItn5SZp81SHgF8GErfIEVemm2Hm/CF3+fa9kVHD5Kil0xfG6prK9CfAdq/THI3pTWVyjfQBq/Y7ksBG9gbXBntTKvw7cZXkqwYpD3ALuMMT8Nuh4cX78a3ylvWLZdJyIl4tuUz79RX6LtGiki5f7H+AYbt1vl+2cd3AD4txh/AvioNXNhFdDm774miUEttXTXVxDR1s/TwMUiMsYKi1xsXUsoInIJ8FXgPcaYrqDrNeI7ERARmYmvfvZZtp0SkVXWd/SjQe8lkXZF+7ml8vd6IfCWMSYQ8kllfYXzDaTzOxbP6Hem/+EbbX8bn7rfluKyz8PXTXsT2GL9XQY8AGyzrj8BTAy65zbL1t3EOTPBxq6Z+GZkbAV2+OsFqAaeA/ZY/6us64LveNG9lt0rklhnZUAzUBl0LeX1hU+IGoF+fK2uT8RSP/hi9nXW38eTZFcdvjix/zv2Syvt+6zPdyuwGbgyKJ8V+BzzXuDnWDsMJNiuqD+3RP9eQ9llXf8d8OkhaVNZX+F8Q9q+Y7rFhKIoSp6Ty6EhRVEUxQEqBIqiKHmOCoGiKEqeo0KgKIqS56gQKIqi5DkqBIqiKHmOCoGiKEqeo0KgKA4Q3371b4nIb0Rku4g8KCIXisgr1l7wK0VktQzsZ/9P/wpuRcl0dEGZojjA2iWyDt9OkTvwbYmwFd8q2vcAH8e3p/4PjDGvWBuK9ZiBLaIVJWPRHoGiOGe/MWab8W2ktgN4zvhaUtvwHWzyCvBTEflXYLSKgJItqBAoinN6gx57g5578Z0S9gPgk8AIYL2InJZi+xQlJgrTbYCi5AoiMssYsw3YJiJnA6cBb6XZLEWJiPYIFCVxfNEaSN4KdDP4tDBFyVh0sFhRFCXP0R6BoihKnqNCoCiKkueoECiKouQ5KgSKoih5jgqBoihKnqNCoCiKkueoECiKouQ5/z+PYmz0dUSK0QAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEWCAYAAABrDZDcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJztnXecXFeV57+nOqqTYivnaMtykGjLcsA2xjiDwSQTFjMEM4RdYJhZDGaH2RmYZYk7ZhjAgAfM2IAZ7LEHm7FsYxsnSW4JZVlWK7fUarW61TlW1d0/3qvq6u56r17ldL6fT3+6+tWp+07dqj6/e89NYoxBURRFKV582XZAURRFyS4qBIqiKEWOCoGiKEqRo0KgKIpS5KgQKIqiFDkqBIqiKEWOCoGiKEqRo0KgKIpS5KgQKIqiFDkqBIqSACJyl4j8+7hr/yQi92TLJ0VJFNEtJhQlfkRkEbAPmG2M6RaREqAZeIcxZlN2vVOU+NAegaIkgDHmKLANeLt96RqgX0VAyUdUCBQlcR4E3mc/fr/9t6LkHZoaUpQEEZF64BiwAtgNXGqM2ZddrxQlflQIFCUJROQPQCkwwxizNtv+KEoiaGpIUZLjQeBaNC2k5DHaI1AURSlytEegKIpS5KgQKIqiFDkqBIqiKEWOCoGiKEqRU5ptB7wwY8YMs3jx4my7oSiKklds3br1jDGmPpZdXgjB4sWLaWxszLYbiqIoeYWIHPVip6khRVGUIkeFQFEUpchRIVAURSlyVAgURVGKHBUCRVGUIkeFQFEUpchRIVAURSlyVAiUuGg63cPmQ+3ZdkNRlBSSFwvKlNzh2u/+CYAj37g5y54oipIqtEegpIRfbznGXb/bGfW55/afZnAkkGGPFEXxigqBkhLuengXv371+ITr+1q6+fC/vspXH90z4TljDIvvepzvbNyf8H3/sKuFtp4hx+eH/AFaugYSLl9RigEVAiWtdA2MAHC4vc/R5vt/bIp6fXAkwPeeep0hf/TeRPfgCJ98YBsf/tctjmV/4aEdXPp//shIIBiH19nlpaYzPLDZ0xYxrgSDhrN9wzHtjrX3J30vJb9RIVAyQwInov7sxcP80zMH+PlLR6I+HwhYhZ7odG7xP7W31bINOjvQ1T9CR4yA2XS6l6MuYgbw8LZmntxzytXmy4/s4jMPbnO1+cBPN3P3I7tdbYwx+GOI2z8/28Taf3iK1u5BR5v/3HGSK7/1LM/tP+1aVmf/MKk41nbjnlM0HulIuhwltagQKGlFknhtaFxhyO8e8JKNTxf+/UbW/cNTrjbXfvd5rvrWc642f/XQDj7xy62uNg9uPsbvd7bE6+IEvvzIbpbf/QdXm417LVE63e2cOtt1oguA/ad6HG2az/Zz0d8/xb1/OuR6v/tePMy+lm5Xmzt/uZV3/egVVxsl86gQKDmPU6CXOFQmBY3ZnOJXW46ltDy36mk+a/W4nnnNvdfw97/fy43/9EIKvVIyhQqBkhFMArmhZHoT4TJSUUie41b3Wj0KqBAoaUYyEIm95K4TEaJ8R1Id5ouvCosGFQIlIySTmnEK4l4CXcqDYR7ipe7dbLQGCx8VAiWtJNUhiPHiYmzlx4Onutcor5BmIRCRBSLyrIjsE5E9IvJZ+/o0EXlKRA7Yv6em0w8leyQ1SFtoI7xZwkstehFVFd7CJd09Aj/wBWPMucAG4NMishq4C3jGGLMCeMb+Wykyko3zmvZJHq1DBdIsBMaYFmPMNvtxD7APmAfcCvzCNvsF8PZ0+qFkj3SmhkJoO9Udt1rUVr4CGRwjEJHFwFpgMzDLGNMCllgAM6PY3ykijSLS2NbWlik3lXyiiNcRxEOybz0TM7+U7JIRIRCRGuB3wOeMMe5LD22MMfcaYxqMMQ319fXpdVBJO9kaKijmGOZtrLiIK0gJk3YhEJEyLBF4wBjzsH25VUTm2M/PAdyXLCp5S1KZIa+GXqZHJuFHvuNpnUWSU0yV/Cbds4YE+Bmwzxjz3YinHgPusB/fATyaTj+U7JPMhmXJxJ+ibu966A556TEVc6+qWEj3CWWXA/8N2CUi2+1rXwa+ATwkIh8FjgHvTrMfSpbISBDRQJVWtCdQ+KRVCIwxL+L8b/rmdN5byQ1SEURixvkiDlTGmJiDuW7VoxqqgK4sVvIAp0CmKQt3UlU9Ws+FjwqBklaSCSJeX1vEHYKUpW1SceiMkr+oECgZIVqYSXp+ezz310CXNFqDhYsKgZJmUpBXSCKI62Ko5NEaLHxUCJScxetip2Ju7XvaUM5ti2kPVVy8tVs8qBAoGSHbsboYg5l2hhSvqBAoaSUTwcgt/aOxELzIoB5MU9yoECgZIZ0t8lRtoZCPuL133WtI8YoKgZLzOK8j0CCWKryNNRSomioqBEpmSCRkp3IdQaFqRvJbTKfGRslvVAiUjJDttqQ2Zt3xtPto+t1QsoQKgZJWXE/H8hidkwri2ppVEVRiokKgZIY0RCPNWcdaI+BdBT2liDyXpuQbKgRKWknFgG5KctSqGa5oaqi4USFQcp6kjqpMnRt5S/LbUGstFjoqBEpGSCSWew0/3lqzhdmedXtfcW3KV6D1o3hDhUBJK6nJ6miQSgZXoYwj76ZDMoWLCoGSVpKa8ON5HUHsuxTqCtpkN5TzUo5S+KgQKEVBMfYqvAT3eORRF5YVLioESlpJZ+zwtqJYo1eq0F5D4aJCoGQEDSKZJ1UaqFpa+KgQKGnFLYhkUhuKWYh04Z0SCxUCJeeJFcdSNWBaaMQzQO5p99HEXVFynKwJgYjcICL7RaRJRO7Klh9KZkhksDaV+f1CDWLJNvZ1awkFsiQEIlIC/AC4EVgNvE9EVmfDFyW9FOq0zXyiUEVQSR3Z6hGsB5qMMYeMMcPAr4Fbs+SLkuPECmTFHOhce1pxLS0u5lpUsiUE84DjEX8329fCiMidItIoIo1tbW0ZdU4pPHTANDqp6rFp/eY32RKCaN++Md8kY8y9xpgGY0xDfX19htxS8olUL5gqZjyFcQ32BUu2hKAZWBDx93zgZJZ8UTKAxpD0kJHB4mKeelUkZEsIXgVWiMgSESkHbgcey5IvShrJlRhSzDrkaXfWYq4ghdJs3NQY4xeRzwBPAiXAfcaYPdnwRckMyQSamK9N0SldhUbxvnMlXrIiBADGmCeAJ7J1fyX7xArwRRzDPeNtIZiH3Vm1rosaXVmsFAXFmPrQbagVr6gQKBkhnXGmGLeYDpHstM2QVnipQzcLFZL8RoVAyV/iCD6FJhap3lnUdb+m1NxKyWFUCJScJ1YQd1sUFX6msHQgZYQG07V6ihsVAiWtJNNy9brq1fUA9wJvznpbCJaie6laFCwqBEpRUIwxLK5tqIuxgpQwKgRKRkhqUDOJ8whCySENdNEJjxEUpVQqIVQIlLSSzKZmo0EqifsXeKDztGrY5Tkvn0+hp9cUFQIli2QiOIenRxaYDngZBI8rgHsSFGejAqveokOFQMl7XFu8KehV5CKjs308zP9PUixE02sFjwqBkla8zFN3fC2h10Z/caGme7zgpacTT1rMk5gWb3UXPCoESlpJavqoxwDk5RaFdnCKl56Op/y//bvQ6keJDxUCJSMkdHg93hY7eQmGhRrnvARwT72GJAedlfxGhUBJK8kEYq9Byi0YFuqMFy8iGU+vwVtqSKWgUFEhUNJKKgZrY/Um3AOdbVNoMSyunUVjC6X7XkMFqqZKGBUCJa1kIgftnvrwPrsmH/H23pPDi1hobyG/USFQ0kqupGYKLU552T46VVVf6IvyFBUCJUMkEkLCLVqHFxdacI8HGVWC2CS5WKzQB9wVFQIlxUxMETgPEqRiWqhXCjWGeRssdhsj0CCvqBAoKSaVASUVs1XyecaL6yCvh1a6FyHNkcydkmVUCJSU4hSXEkoNJfHacBl5vMVEylYNe1pH4GFmUcw7KfmKCoGSUhy3g0igRZ6KtEWh5re9bTGR2l6D22dYYNVbdKgQKBkh+4Ei+x7Ei3v+38NCMA/leLlXPDZKfpI2IRCRb4nIayKyU0QeEZEpEc99SUSaRGS/iFyfLh+UzJNrwSJXpq8mgvsYgQcbT2mfOHpMufbhKikjnT2Cp4A1xpgLgNeBLwGIyGrgduA84AbgX0SkJI1+KBkklVM9Y+XB4ykyH1NDybsczzYUmvYpZtImBMaYjcYYv/3nJmC+/fhW4NfGmCFjzGGgCVifLj+UzOIctBPZdM5+bVJjBKH75x+eNoJLckO5FJ9do+QpmRoj+AjwB/vxPOB4xHPN9rUxiMidItIoIo1tbW0ZcFFJBSld/JWiLRISvn+WcRVPTwfKjJaUCvJxCq7ijdJkXiwiTwOzozx1tzHmUdvmbsAPPBB6WRT7Cd8wY8y9wL0ADQ0N+g3Mc5I7mCbx+xbqXkPxHEzjBd2GurhJSgiMMde6PS8idwC3AG82o82JZmBBhNl84GQyfiiZxxgTDrIxLBO+x2jxSZQRKiEPo1iqNtNzfe9x9LrcN53zUICSs6Rz1tANwBeBtxlj+iOeegy4XUQqRGQJsALYki4/lPSg+/9kl3i2j07VNt2F1qtSRkmqRxCDfwYqgKfs1ssmY8xfGmP2iMhDwF6slNGnjTGBNPqhpAHnFcSpW1CWSvJRoLwM8no7UCa2jSZ+ipu0CYExZrnLc18Hvp6ueyvpxwrsE1ND8QTc2JvOpWBVcB5voewt7eNla4jk9izKRxFV4kNXFisJEe+eQklMGnJJQ8UutfDHCFxsvBxen+IBZSU/USFQEiLe4JzUrKGkBpzzeGmxC3HN/09yPUI8Nkp+okKgJES8q30TWlDm8fB61zJC98/DIJbsTB6XoyDGmyhFjgqBkhDxBtZo9rHEwcusF8/3z8cxAg/5f7faiee86GTHI/KxfpVRVAiUlOKYMsqsG2HyOTMUSybB2ziCaylx9Lo01BcuKgRKQjgGjnHXcyUlkyt+xIO3g2mSw8uAsrb2Cx8VAiUhUrm5nCMpGSNIXXop4yS76ZwHmzhulZdiqnhDhUBJiHhXFkcdI4i5jsC2S8k21IUVxbzMqPJ0nGVcqaHCqkNlFBUCJSHiXy+QyKyh5PMf+Xzerqcgn2SPIJ4pugWmpUoEKgRKQsTbwk5uHUHy5GMQ87SPkJdFZ14GlPOwfpTUoUKgJIRjj8BpQVkcZYTI5xk/qcDLPkJueNqPyIONF3/yUWiVUVQIlISId5po9nP02b5//CQ9/9/DmcXe/Ejq5UoeoEKgJEa8g8XJ3CqJSBTP4ezZF6uxJDuTx8vU0HjIsepRUogKgZIQXqePJrVxaArS13GlPvIo0KXqrGGJq9eQRxWkxIUKgZJa4ogVsYJPrAFRL7Ern1fOJj8QHCootk2hCaUSHyoESkLEP0YQ/z1SOaHFU749xyKdpymdXvYaSvI8gtF7KYWKCoGSEPEGhWSCbHJjBAm/NK14ek9eWvKpsontTc4JpZI6VAiUhIj33IFEQkgqzxLItQx4si1wLwE85YPFKS1NySVUCJSEcF5Z7F0JMhFY4kp9ZDDSpWpGkLcppl7u5bImXBWg4FEhUBIi7r2GkrlXEq8dLSPJOfkpJlVpFm8zgtxsvG/Kp4JQuKgQKAkR9wllCUQRD2evxC4jjvmjOdcjSFKYvB1eH4dDSsGiQqAkhmOPII4tJmIEH0+7Z8YglfsVZZpkB4K9HF4Tnz/5WIuKF1QIlITwGhJScpaAY7rJ+0KCXIthSQ8We7KybVM0ZpxjVaikkLQLgYj8tYgYEZlh/y0ico+INInIThFZl24flNTjdYwgFKwTiUWpOLw+HjKbGkpuXUM8W2d4wssH5HKvXBNaJT7SKgQisgB4C3As4vKNwAr7507gh+n0QUkP8aZrEpo+msBrnO+fa4PFydlkcuuMUL24FaOH1uQ36e4RfA/4n4z9Dt0K3G8sNgFTRGROmv1QUoznHoF79PB2r1SMEeTYYHGq8LTFRIrukaNr85QUkDYhEJG3ASeMMTvGPTUPOB7xd7N9bfzr7xSRRhFpbGtrS5ebSoJ4XUeQiuCazMKoXD13JecGcJMcs8hHEVVGKU3mxSLyNDA7ylN3A18Grov2sijXJnyNjDH3AvcCNDQ06Ncsx/C6sjjbKYPRHkFqFl6lilQdDZmszzqQrECSQmCMuTbadRE5H1gC7LAHteYD20RkPVYPYEGE+XzgZDJ+KJknE5vOpTK45NpeOkkfFp+iXVVTlTLTqaX5TVpSQ8aYXcaYmcaYxcaYxVjBf50x5hTwGPAhe/bQBqDLGNOSDj+U7OMWH2K1imPGFk+zR703eXMtlCU7vhLXRCAXY28D7Uo+k1SPIEGeAG4CmoB+4C+y4IOSJM6DxdGfSCQFEVMo4isstknOrSz2YpOc0+HPK8mpodohyG8yIgR2ryD02ACfzsR9lfThdYuJZAJErNcGPRTuZU/+bJDJQd6M3CK3qleJE11ZrCREvAvKErqH/dupNxFPLM21kxhTNWbhLUinptfg1qnLNaFV4kOFQEkI5397b7OJnK6NfT751FB8R1WmJph5Ow3NQzme7uXByMPr3d57JvxQsosKgZIQnqePpjFABINeUkOZ32Y5Vb2PlImXywBNrkxjVbKLCoGSEF7/8ZMJEJluZXoZc0jZQTBJ7jU0auPhZh4IBj3YaLO/YFEhUBLC6zoC15OvYt0jtMeNg6GnwG2X4cU24MHGQyfEUwD3Uo6bP6FGvtv7Gk2LuXwGJnY5hOvQxUJFIq9RIVASxPtYgBNeW5iOM5Q8zaW3oqGXNFKqWsVeBCXgwR83G58d5d38KZHY731UCJz9SNU4gpK7qBAoCeH1jAC3ABErqMYcTHZ/2sJuFXsKzikK4KkSFLdyQkIQcLGRsFg424Se8tJz8yIWSn6iQqAkhNP/fTyDxbFnDbnbxZOz9pKK8dRr8JT2SVGPwEPaJ9leQ0gA3G3G2ka10T5BXqNCoCSEU+CYeNnO80cJFLGCYayWaFxpqBQF+WQDeFzlJBnkfR7EInwvD/l/12JUB/IaFQIlIZyCy/jA5JaDjp0aMmN+Oz3vRmjiZLKBN0Su9Cx89n+um8+jA8rO9/DW2o99L9WB/EaFQEkIp/z1+HgSCh5R9x6PET1iCoX7y8f6kaKUjpcgnzLR8TTI62wT9GAzYn+QPpe1BiFffS5Li0fcBiuUnEeFQEkIp8A6/ro/HEQmRpFYwXDEzlf4HCKQp1lDHqZQhkh2Smc8NsnOPgr56laHoXu42fgD3oO8m1j43XJLSs6jQqAkhFNwGX89FERKokSaWMFwNAC5P+8FL6bJttJHbVLjj1s5xkOQNx7EwkuQjyXIAH4Pb9pL/SrZQYVASQjnweJxPQI7iESLM/4YgSH02mgiAjDkj0MIMjkQnIF7herfTUxDwdndJvT5uLX23QUZRsXCDU0f5S4qBEpCeO0R+F1y0IMjAdd7hPLXTkFq2IMQhGySGcCNFDen9x1pk7LBYte0T8gf59eHhNQ9NeQhyNuvL0kyNRQp/F7qSMkcKgRKQjj9I4+/POzSqh8ccQ/k4R6BQwAa8rsLiWUTu1Ucwik2RfrpVExk7yRVg8VeArhbryEktG42wy49thAj/tjpo+FA7M9iJLKOdAVaTqFCoCSE0z/y+IA7ZAej0qhC4B48+ob9rs/H0yNwnO4ajN3a7x3yx7Tpi7BxEp1I4Up2+mjfsFWWW8u6Z9DvwWbEvpezHyGbqoqSmPdyI9JGN7DLLVQIlITwmhoK/fPXVEw8DC+WEHQPWK91Ep2ugZGYfg7awdcp8PSPxA7O/RGC5ORLrwch6BuKfa8xKSaXYNlv38+t1xCqe7f0UaiO3cSi2y6nutz5QEMvn0X34KiNlwF1JXOoECieiQwWkUHKLXh1u7QmO2MEj9BrnaZ+nu0ftsoud26pnu1zb/G29w6FHzsF1Y6+4fBjp4DZ2T/6XpwCb2f/cEybsb2P6DbGmNEegYtYhIKzu43lk1uqJvzeXNJHXoRgTB1pjyCnUCFQPNM7HD1IRebQxwcdt5RBW48VhMtLon8NO3rtIOUYoG2RcRCCQNCEA6tTGa3do0LgFORbugZHy3QIYCc7B8bcN7rNYEybE5HleOgJuQ1eN5/td7Wx7jfowcYqx63XEOm3k3CH/AFNDeUaKgSKZ7r6owegUEC3ro99TWv3YNTrAGfs1nhFafSvYXNnKJBF9+d4h3uga+kaDU5OQSwygDvFOS9B/sSYchIPhM0dsX0+3hFbLM72j4R7DU42xphwHbrF5WP2/dxa8cfaR9+bUx0d7Yh4/zprKKdQIVA80xaRRokMZG5BsPms9Vy0VuJxlwDjDwTDLWinoHmwrdd6vUNQOdDaG37sFMT2neqOabO3ZdTGKRbua+kZLcfBn30R5TjZ7PVgE1mOU0DdN8ZnZ0GJ1WMaHAlw8HSvfa+oJgC8diri/Tvc77VIv1UHcgoVAsUzoaAOYwPHGCEIRheCaIHmwOkex+cOtvWFr0cTgiF/gENn+gDn4LzXQ+DZezJ2UN19oiv82Clgbj9+lrIS+4wAB4e2H++ksswX02ZSWYmrzbZjZ6mtLLX9iWrCtqNnAStt5uTztmOWzZSqMsd77TnZxXAgaNk4lNPWM8ThM31Mqy4HogtGMGjYavtk+a1KkEukVQhE5L+LyH4R2SMi34y4/iURabKfuz6dPiip43hH9NTG4TPRW95n+4bD6Z/xgWZgOMAxl7TE9uNW0Jg8KXoA2tXcxbA/yMJpVY5B7JWD7aycVYNPogf5wZEArx7pYN3CKZaPUWxauwd5vbWX9UumRX0fYKWgDrb1hW2i3aujb5jdJ7vZsHS6o83gSIBNh9q5dJllE60lb4zhhQNnuMTFH4A/HWjj3Dl1TK0qdxSL519vY/KkMs6ZXesogs/vb8MnsH7xNOd7vd4GwKX2e4tmt725k+5B/2gd6RhBTpE2IRCRNwG3AhcYY84Dvm1fXw3cDpwH3AD8i4g4T/tQcoZIIYgMmvtaesLrBCLjye6TVkt6Rk35hGC//XgnxsA5s2ujBo5tRzupqyxlWX111KCx6VA7ABuWTosawAdHAmw50sEVy+sp8UnUe2w+3MHgSJA3nzvL9n2izTP7TgNw3WrbJsq9Nu5pBeCGNXPsciaY8PTeVgJBw022TTSfXzxwhv7hADeumW3bTCxnR3MXJzoHuGHNHEeBa+0epPHoWW5cMxufL/r7GhwJ8PTeVq4/bxZlJb6o9WOM4fe7WtiwdDr1tRWOYvH7nSeZN2USa10E9T93nKS81DdajyoEOUU6ewSfBL5hjBkCMMactq/fCvzaGDNkjDkMNAHr0+iHkiL2tXQzf+okYOw/+96T3Zw3bzIwNjDtslMqF8yfMiE4bDncgQhsWDo9yhkGhmf3n+aKFTMo9fmiBpaNe1u5YP5kptdURA0qf3ztNMP+INecMxOfSNQg9uj2E9RUlIZb4NHKeXT7CRZPr+LcOXUT3neI/9h+ghUza1heX+No8/Cfm1kwbRLnz5/seK9/39rMlKoyrlgxwyonis3D25opL/HxlnNnOQrcw9tOYAzcdP4cSkSi+vPknlP0DPm55YK5lPii18+2Y50causL20S716muQV44cIZbLpwTXj0+vqzBkQCPbT/Jm1bVUzepzLGOlOyRTiFYCbxRRDaLyPMicrF9fR5wPMKu2b42BhG5U0QaRaSxra0tjW4qXhgJBNl3qocLF1itvlAgO90zyKnuQc6fNzFQbjvayeLpVVHzy5sPt3Pu7DqmVJVhzNg0yJ6T3ZzuGeKac2bZLdqxvhxt72Nncxe3XOAc6B7e1sysugouXTbdCnQTprWO8MSuFt564dzwQqnxLfCm0z1sPtzBey9eOHpG8LhydjV38edjnbxv/cLRQDjO5rVT3Ww61MEHLlkUthl/rxOdA2zce4rbL15IRanVQR4fULv6R/htYzNvu2guk6vKogrcSCDIL14+wuXLp7N8Zg2+KAHcGMPPXjzM0hnVXLF8hlWHUYL8z148RF1lKbdeNBefQz3//OUjBI3hg5HvbVxZj/z5BO19w9xx2eLwdiG6oCy3SEoIRORpEdkd5edWoBSYCmwA/gZ4SKzdw6KeUTLhgjH3GmMajDEN9fX1ybippIADrb0M+4NcND/U/beubz7UATCa+7aDgD8QZPOhdi5dZgWayEDfPTjCq0c6uHz59NHAEPEN2Li3FRF406r6qMHu9ztbAKvF6/MJwXFCcqZ3iOf2t/H2tfMo8YkdxMa+n8d2nGRwJMh7GuYTWsYwPoA9uPk4ZSXCuxvmRwTwsTb3v3KEqvIS3tUwn1J7sHj8Lpu/ePkoFaU+3tuwIFzO+G2bf/nKUQA+uGFheNB5/F5Kv371GAMjAT5y+RLAWn8xfgfWJ3a1cKp7kI9eYdlUlZcwMDy2nFePnGVncxcfuWIJPp9QUeabsO/T8Y5+/mv3Kd5/ySKqK0qZZJcTWc+9Q34e2HyUG8+fw4JpVeFB7v7IFdRBw09fOMSaeXVcunR6+GQ1TQ3lFkkJgTHmWmPMmig/j2K19B82FluAIDDDvr4gopj5wMlk/FDST2jmzMX2YN+AvTXDpkPt1FSUcuH8sT2FHc1d9Az5uWL5DCsQR/zjP7e/jZGA4frzZof3uA8FWGMM//HnE1y2bDrTayompCSCQcNDjcdZv3ga86dWhccmIgP0g5uP4Q8a3v0G62tWXuobu89P0HDfi4dZPaeOixZMCbfAI7e86Owf5jevHuOm8+cwo6aCantldOQ2Ea3dgzy64yS3rZtHXWUZtfY2GpGrg1u7B/ndtmZuWzePqdXlYZvIhXZn+4b55StHuPH8OcyfWkV1eSk+GWszMBzgJy8c5rJl01k91+p91U0qG7NtQyBo+Oc/NrGsvpqrV84ErMH27nGrfu955gDTqst557r5VjmVZRNWBn//jwco9fn48GWLw+X4g4b+CFH5xctH6Bn0c+cbl4ZtYOyCt//ceZKDbX3ceeUyRMSxZ6Vkl3Smhv4DuAZARFYC5cAZ4DHgdhGpEJElwApgSxr9UFLArhNd1FSUcp4dhEIbkW061M76JdMos5vVoa2GXzxwBhG4bNl0Kz0R0eB8cs8pZtSUs3bh1HCN1GFnAAAbCklEQVTrd9g2aDx6lmMd/dy21gpSlWVjW7QvNJ3haHs/H9iwEIBqO7CGAvSQP8D9rxzl6lX1LJ9p5ezrKkvHBNVnXjvNwbY+PnHVUkQknLeODJg/f/kIfcMBPnn1MrsM2yYi8P7wuYMEgoZPXGnbhMvxj7EJBg2fvGr5GJvIYPmTFw7RPxLgs29eAVgHwNSNC+C/3HSEM71DfP4tK8PXLJvRe/3njpMcON3L59+yMiywdZVjxeLlg2d4sekMn7p6GZPsFdmTJ40VgoNtvfz71mY+uGERsydXhm0i3//ZvmF+9NxBrj13VjhdON5m2B/kOxtf55zZtdxyvjVI7jSOoGSXdArBfcBSEdkN/Bq4w+4d7AEeAvYC/wV82hgTew9bJavsOtHF6rl1lJX4qCovoWfQT/PZfg629XHZsunhvYRCQfv510+zZu5kplaXM6mshAF7e4rBkQDPvXaat6y2BjtrKqzg0WsH6oe3NVNVXsIN9syZ2nFB/IFNR5leXR5+vs6eTx8KPr/f0cKZ3qFw+gQmtpx//PxB5k+dxM12cKqtKEVkdHO13iE///rSEa49dxbnzB5tfcOoWJzuHuRXW45x29p5LJhWZfsyNsif6hrkwS3HeOe6+SycbtlUlpVQXuoLl9PRN8wvXj7CLRfMZeWs2lGfI1rpvUN+fvjcQd64YgYXL54Wtpk8qTRczkggyPeefp1z59SFZyaNL8cYw7ef3M/suko+uGHRmPoZ9gfDn913n3qdyrISPvWmZRH3st5baL+gHz1/kN5hP39z/aox5UTa/KbxOMc6+vniDeeEhckXJRWoZJ+0CYExZtgY80E7VbTOGPPHiOe+boxZZoxZZYz5Q7p8UFKDPxBkX0s359szg2orS+kd9PPUXmva5LXnzgoPuPYO+TndPci2Y528xZ4qWFtZSt9wgEDQ8Nz+NvqGA1x/3migB6uHMTgS4Pc7W7hhzexwS7+usizc+2jpGuDpfa285+IF4XROZAvbGMN9Lx1mxcwa3mjPvAndIyQmjUc6aDx6lo+/cSmldi/G5xNqKkaD6oObj9I1MMKnIwLheLH48Z8O4Q8aPnPN8rBNZZmP8hJfeHO5Hz7XRHCcDcDUqjLa7Y3sfvz8Qbs3MNZmWnU5p+2tO+578TBn+0f4wnWrxtjMqKnglL2Fx0ONxzna3s8XInoDALMmV9LWM8TgSICn9ray7Vgn//3Ny6ksG52xPXeK1epvPtvPjuOdPL6zhY9dsYQZNRVhm3lTrNlixzr6OdE5wM9fPsI71s5j1exR8QrNKDvS3kf34Aj3PHOAixdP5epVo2N84dSQKkFOoSuLlZg0tfUy5A+GhWBqVTlneof4r92nWDWrlsUzqinxCVXlJfQO+tm4NzSvfmyw7x3y87ttzdTXVnDFcitQ14SEYMjPY9tP0jPoD+f2wdq+unfITzBo+PlLRwB4//qF4ecjW+HPvd7GnpPdfPSKJWNONQv5C/C9p19nenU5726YP+Y91tdW0NI1QPfgCD987iBXLJ/B2oVTw8/7fMLcyZM41t7H8Y5+frnpKG+/aB6LpleHbUSEhdOrONjWx8G2Xh7YfIx3NywI9xhCLJ1Rw4HTvRxt7+NfXzrCbWvns3xm7RibFTNreL21l5OdA/zwuYPccN5sLrJTMCFWzqrlWEc/JzsH+PaT+1m/eBpvPnfmOJsagsZaIfwPj+9l+cwa3tOwYEI5YK37+Mp/7GZmbQUfv3LpWH9m1SBizej66qN78IlMEKbayjLmTZnE7hNdfOfJ/ZzpHeIrN68e81mEVlYPejhUSMkczhuMK4rNrmZroHiNLQTLZtbwuD1z5wsROetQ0H5iVwtLZlSzIpyjt4L1sfZ+nn3tNH9x+eJwa3yK3aLv6B3m5y8fYdWsWjYsHU1/zJpcSdDA66d7+LdNR7nlgrljAusiO+VyyM5rz5syidvWjQ3yy2fW8PiuFjbuOcVLTe38r1tWUzVub/1Vs2rZc7KbHzzbxNn+Eb54wzkT6mHlrBp2nujia4/vxSfwhetWTrA5Z3Ytrxxs5+5HdjGprIS/estEm/Pm1nHfS4f51APbKCsRvnjDqgk2FyyYwm+3NvPuH71C0BjuvvncCTbrbKG66Z4X6Bn0879vPW/CsZ4Ni6YhArffu4mRgOHBj18SHs8ZfV+1TK8u5/O/2QHA99+3llr7MwtRVV7KuoVTueeZAwB8+aZzwr2ESK5aVc+Dm48B8OHLFofHD0KEenqRM4uU7KM9AiUmu090UV1ewtIZVuu3YZEVgEp8wnvXj7Yu62srePlgOy8fbOe2tfPCQSk04Ph//rAPf9CMaZEunWGJxb0vHGJvSzcfvnzxmGC2ym6tfvz+RvqGA/zlVaPpGoA5kyuZWlXG/3p0Dzuau/jstSsoH7eb6dqFUzEG7vzlVhZOq+IDlyxkPJctm86xjn5+/Pwh3tMwP7zwK5Jrzp3FobY+ntzTymffvJK5UQLhWy+cS3vfMJsOdfDlm8+lvrZigs1t6+ZjsFvXbz2PmXWVE8u5YA7Tqss50TnAP9y6ZkKvAuDSZdM5b24dnf0jfOXmc8OL3iKZPbmSD1yyEH/Q8MUbzuGyZTMm2JSV+Pjr61dRW1HKp9+0jLdeOHeCDcDfXL+KeVMm8YFLFvKxK5ZGtfnU1ctYu3AKt62dx5dumiimoS3DY50+p2QW7REoMdl9spvz5k4O555vv3ghrd1DrF8ylZm1o0Fs9Zw6frvVWvn6notHg31optHLB9t58zkzWRExKDq5qoxVs2rZcriDJTOqw1MaQ1y4YDL1tRUc7xjg/ZcsDE+dDCEifHDDIr7/xyauXlXPu8a9HuCK5TO4YvkMXjvVw/fft3ZMfjzEO98wnxcOnKGsxMffvvW8qPXwnob5HO/oZ/KkMj5xZfRAeN3qWXz73RdSWebjlguiB9TVc+t4+JOXMewPcom9/mI8U6rK2fj5K+kaGGGZvWJ5PCU+4ZFPXU573xBzJk8UpRBfe/v5fOXm1VHfd4j3rV/I+9ZPFMhINiydzkt3XeNqM39qFY986nLH50NjSf0qBDmFOG1Rm0s0NDSYxsbGbLtRlASChjVffZLb1y/gqw4BMsS+lm6+8NAOPrhhEe8f1+r+zsb9vNh0hntuXzuhdbvt2Fn+bdNRPnnVsjEiEeK1U91sP9bJbevmT2jtgzUbpul0L0tmVIdTTtEwxkxInSiZ5XTPIOu//gxfe/uaMTOXlPQgIluNMQ2x7LRHoLhyqK2XgZFAeKDYjXPn1PHEZ98Y9bkvXLdqwuBiiHULp4bz3dE4Z3ZdeBpnNEQkqoBEs1OyS+TsMiV30DECxZXQxnFrPAiBosSiqryESWUlY061U7KPCoHiyu4T3VSW+Rzz1IoSDyLC7MmV4fUPSm6gQqC4svtEF6vn1IW3BlCUZJlVV8FpFYKcQoVAcSQYNOw52aVpISWlzKrTHkGuoUKgOHKic4C+4YDrQK2ixMuCqVWc7BycsF23kj1UCBRHQofLr5yl4wNK6lgyo5pA0Iw5+lTJLioEiiOvt1qH0q+YGXtqpqJ4ZUm9tUL98Jm+LHuihFAhUBw50NrLzNoKJleVxTZWFI+Etio51KZCkCuoECiOHDjdM2aPfEVJBVOqyplaVcYh7RHkDCoESlSCQWvbhtApX4qSSpbV13CgtSfbbig2KgRKVE50DtA/HNAegZIWVs+t47VTPXpkZY6gQqBEpanNGijWHoGSDlbPqaN3yM/xszpzKBdQIVCictTO3y6eMXEffEVJltB24ntPdmfZEwVUCBQHjnb0U1VeQn3NxINVFCVZVs6qpcQn7G1RIcgFVAiUqBxt72fhtCrdullJC5VlJSyrr2a3vbutkl1UCJSoHG3vC58HrCjpYO2Cqfz5eKcOGOcAKgTKBKzl/wMsml6dbVeUAuYNi6fS2T/CQXtigpI90iYEInKRiGwSke0i0igi6+3rIiL3iEiTiOwUkXXp8kFJjFPdgwwHgtojUNLKxYunAfDqkbNZ9kRJZ4/gm8D/NsZcBPyt/TfAjcAK++dO4Idp9EFJgKPt1oyhRdO0R6Ckj8XTq5hRU07jkY5su1L0pFMIDBDav3gycNJ+fCtwv7HYBEwRkTnpcOBU1yAf/Olmnn3tdDqKL1iOtVtzu7VHoKQTEaFh0TQ2H+7AGB0nyCbpFILPAd8SkePAt4Ev2dfnAccj7Jrta2MQkTvtlFJjW1tbQg5Mqy5n27GzbNx7KqHXFyvHz/ZT4hPmTK7MtitKgXP5ihmc6BzgoG5Al1WSEgIReVpEdkf5uRX4JPB5Y8wC4PPAz0Ivi1LUhOaAMeZeY0yDMaahvr4+If/KS33csGY2j24/SVf/SEJlFCMtnYPMqq2gtETnEijp5eqV1v/2c/u1155NkvpPN8Zca4xZE+XnUeAO4GHb9LfAevtxM7Agopj5jKaNUs7HrlhK/3CAf9t8NF23KDhOdg0wZ8qkbLuhFAELplWxfGYNz7+eWK9fSQ3pbPKdBK6yH18DHLAfPwZ8yJ49tAHoMsa0pMuJ1XPruGplPT954RDdg9or8EJL16CmhZSMcfXKejYf6qBvyJ9tV4qWdArBx4HviMgO4B+xZggBPAEcApqAnwCfSqMPAPzN9avo7B/hJ386lO5b5T3GGFq6BpmrPQIlQ1x33myGA0Ge3teabVeKlrQJgTHmRWPMG4wxFxpjLjHGbLWvG2PMp40xy4wx5xtjGtPlQ4g18yZz8wVz+NmLh2npGkj37fKa9r5hhv1B7REoGaNh0VTmTK7kse1pyxArMSia0cAvXn8OQWP46qN7su1KTtPSOQjAnMnaI1Ayg88n3HLBHP50oI3O/uFsu1OUFI0QLJxexeevXcnGva08vjNtQxJ5z0m7xzR3ivYIlMxx60XzGAkYHtVeQVYoGiEA+OgVS7hg/mTuenhnePWsMpZTXVaPYLamhpQMsmbeZC6cP5n7Xzmii8uyQFEJQWmJjx+8fx0+ET75b9vo1VkKE2jvHUIEplfrOQRKZvnQpYs52NbHS03t2Xal6CgqIQBr3vL/u/0i9rf2cOf9jQyOBLLtUk5xpm+YqVXllPj0HAIls9xy4RymV5fz4z8dzLYrRUfRCQHAm1bN5FvvuoCXD7bz8fsb6dH1BWE6eoeZXl2ebTeUIqSitIRPXLWUFw6cYcth3YgukxSlEADctm4+37TF4D0/3sSRMzpmANDRN8w0FQIlS/y3DYupr63g20/u17GCDFK0QgDwnoYF3Pfhizlxtp+b7nmBX205VvSnJXX0W6khRckGk8pL+Py1K9lypIPfbTuRbXeKhqIWAoCrVtbzX5+7kgvmT+ZLD+/i1h+8xEtNZ4q2NTLkDzCpvCTbbihFzO0XL+ANi6bytcf30tYzlG13ioKiFwKAuVMm8eDHNvC9917Imd4hPvDTzdx8z4v85tVjRbdr6dBIkIpS/Voo2cPnE75x2/kMDAf4H7/6M/5AMNsuFTz6H2/j8wnvWDufZ//6ar5x2/n4g0G++LtdNHz9Ke64bws/feEQO5s7C/5LORwIUq5CoGSZFbNq+cd3nM8rh9r52uP7iraHnilKs+1ArlFZVsLt6xfy3osXsKO5iz/samHj3la+9vg+ACpKfSyfWcPKWbUsn1nD7LpK5kyuZNbkSuprK6gpL8WXx1Mvh/3aI1Byg3e+YT57W7r52YuHmVRewv+8fhUi+fu/lcuoEDggIly0YAoXLZjCl246l9buQbYc7mBncyevt/ay6VA7j/x54mCWCNRUlFJXWUZtZSk1FaWUl/qsnxIfZaU+Kkqsv8tKfPjEupdPBBHwCfbjcX/bPomARD3bJzUMjgS0R6DkDF+5+Vz6hwP88LmDtHYP8o/vOJ/KMh3DSjUqBB6ZVVfJWy+cy1svnBu+NjAc4FT3IKe6BjnVPcCZnmF6BkfoHvTTPThC94Cf/mE/w/4gvUPW7+FA0PrtDzISCBI01tbPxkDQGAzW7/HXMzWZSQRWzKzNzM0UJQYiwtffvoZZdRX8v6cPsOdEN9981wVcuGBKtl0rKCQfcm8NDQ2msTHtu1XnPCFhSDf5nNpSCpc/vtbKlx/eTWvPIG+9YC6fuWY5K2dpo8UNEdlqjGmIaadCoChKvtA9OMIPnm3il68cpX84wNqFU7j1wrlcsaKeZfXVOoYwDhUCRVEKlo6+Yf5963F+t/UE+1t7AJhZW8F5c+tYObuWpTOqmVVXyaw6exJHRSkVpb6UCEUgaBgJBBnyBxnyBxgaiXjsD9p/Bxj2h6472w36AwyOhH6CDAwHGBgZvTYwEuCc2XX84iPrYzsWBa9CoGMEiqLkHdOqy7nzymV8/I1LOdbRz0tN7Ww53M5rp3p4qamd4SjTvH0C1eWlTCovoazEmhDh81mTMUKTNYyBkUDQDvaGQDCIP2DwBw3+YBB/MDXp2XJ7wkhFqY/KshImlZcwqcz6qa0sZWZtRfjakhnVyd8wBioEiqLkLSLCounVLJpezfsvWQiAPxCkpWuQ0z2DtHYP0dYzRN+wn/6hAH3DfgaGA/iDxpqcYU/KCBoIGEOJCKU+obREKPH5KCsRSnxCWYnP+u2zrpeWCJVlJVSUjgb0itISKsoiHpf6qCwbfRx6vrzEl3PjcCoEiqIUFKUlPhZMq2LBtKpsu5I36IRxRVGUIkeFQFEUpchRIVAURSlykhICEXm3iOwRkaCINIx77ksi0iQi+0Xk+ojrN9jXmkTkrmTuryiKoiRPsj2C3cBtwJ8iL4rIauB24DzgBuBfRKREREqAHwA3AquB99m2iqIoSpZIataQMWYfEG2Rxq3Ar40xQ8BhEWkCQisimowxh+zX/dq23ZuMH4qiKEripGuMYB5wPOLvZvua0/UJiMidItIoIo1tbW1pclNRFEWJ2SMQkaeB2VGeutsY86jTy6JcM0QXnqjr9Iwx9wL3grXFRCw/FUVRlMSIKQTGmGsTKLcZWBDx93zgpP3Y6bojW7duPSMiRxPwI8QM4EwSr08X6ld8qF/xoX7FRyH6tciLUbpWFj8GPCgi3wXmAiuALVg9hRUisgQ4gTWg/P5YhRlj6pNxRkQavWy8lGnUr/hQv+JD/YqPYvYrKSEQkXcA3wfqgcdFZLsx5npjzB4ReQhrENgPfNoYE7Bf8xngSaAEuM8Ysyepd6AoiqIkRbKzhh4BHnF47uvA16NcfwJ4Ipn7KoqiKKmjWFYW35ttBxxQv+JD/YoP9Ss+itavvDiYRlEURUkfxdIjUBRFURxQIVAURSlyCloIsrnBnYgsEJFnRWSfvTHfZ+3rfyciJ0Rku/1zU8Rrom7UlwbfjojILvv+jfa1aSLylIgcsH9Pta+LiNxj+7VTRNalyadVEXWyXUS6ReRz2agvEblPRE6LyO6Ia3HXj4jcYdsfEJE70uTXt0TkNfvej4jIFPv6YhEZiKi3H0W85g32599k+57UcVkOfsX9uaX6/9XBr99E+HRERLbb1zNZX06xIXvfMWNMQf5gTU89CCwFyoEdwOoM3n8OsM5+XAu8jrXR3t8Bfx3FfrXtYwWwxPa9JE2+HQFmjLv2TeAu+/FdwP+1H98E/AFrDcgGYHOGPrtTWIthMl5fwJXAOmB3ovUDTAMO2b+n2o+npsGv64BS+/H/jfBrcaTduHK2AJfaPv8BuDENfsX1uaXj/zWaX+Oe/w7wt1moL6fYkLXvWCH3CNZjb3BnjBkGQhvcZQRjTIsxZpv9uAfYh8O+SjbhjfqMMYeByI36MsGtwC/sx78A3h5x/X5jsQmYIiJz0uzLm4GDxhi31eRpqy9jzJ+Ajij3i6d+rgeeMsZ0GGPOAk9h7cSbUr+MMRuNMX77z01Yq/UdsX2rM8a8Yqxocn/Ee0mZXy44fW4p/39188tu1b8H+JVbGWmqL6fYkLXvWCELgecN7tKNiCwG1gKb7Uufsbt494W6f2TWXwNsFJGtInKnfW2WMaYFrC8qMDMLfoW4nbH/oNmuL4i/frJRbx/BajmGWCIifxaR50Xkjfa1ebYvmfArns8t0/X1RqDVGHMg4lrG62tcbMjad6yQhcBp47vMOiFSA/wO+Jwxphv4IbAMuAhoweqeQmb9vdwYsw7rXIhPi8iVLrYZrUcRKQfeBvzWvpQL9eWGkx+Zrre7sVbxP2BfagEWGmPWAn+FteVLXQb9ivdzy/Tn+T7GNjYyXl9RYoOjqYMPKfOtkIXAbeO7jCAiZVgf9APGmIcBjDGtxpiAMSYI/ITRdEbG/DXGnLR/n8ZaGb4eaA2lfOzfpzPtl82NwDZjTKvtY9bryybe+smYf/Yg4S3AB+z0BXbqpd1+vBUr/77S9isyfZQWvxL43DJZX6VYB2r9JsLfjNZXtNhAFr9jhSwEr2JvcGe3Mm/H2gwvI9g5yJ8B+4wx3424HplffwfWKW/Yvt0uIhVibcoX2qgv1X5Vi0ht6DHWYONu+/6hWQd3AKEtxh8DPmTPXNgAdIW6r2liTEst2/UVQbz18yRwnYhMtdMi19nXUoqI3AB8EXibMaY/4nq9WCcCIiJLsernkO1bj4hssL+jH4p4L6n0K97PLZP/r9cCrxljwimfTNaXU2wgm9+xZEa/c/0Ha7T9dSx1vzvD974Cq5u2E9hu/9wE/BLYZV9/DJgT8Zq7bV/3k+TMBBe/lmLNyNgB7AnVCzAdeAY4YP+eZl8XrONFD9p+N6SxzqqAdmByxLWM1xeWELUAI1itro8mUj9YOfsm++cv0uRXE1aeOPQd+5Ft+077890BbAPeGlFOA1ZgPgj8M/YOAyn2K+7PLdX/r9H8sq//HPjLcbaZrC+n2JC175huMaEoilLkFHJqSFEURfGACoGiKEqRo0KgKIpS5KgQKIqiFDkqBIqiKEWOCoGiKEqRo0KgKIpS5KgQKIoHxNqv/jUR+amI7BaRB0TkWhF5yd4Lfr2IXCWj+9n/ObSCW1FyHV1QpigesHeJbMLaKXIP1pYIO7BW0b4N+AusPfW/YYx5yd5QbNCMbhGtKDmL9ggUxTuHjTG7jLWR2h7gGWO1pHZhHWzyEvBdEfkfwBQVASVfUCFQFO8MRTwORvwdxDol7BvAx4BJwCYROSfD/ilKQpRm2wFFKRREZJkxZhewS0QuBc4BXsuyW4oSE+0RKErq+Jw9kLwDGGDsaWGKkrPoYLGiKEqRoz0CRVGUIkeFQFEUpchRIVAURSlyVAgURVGKHBUCRVGUIkeFQFEUpchRIVAURSly/j9o5yQT+owItAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xl4VNX5wPHvm8kGIQQIAZSwBAhgQECJCK6oVdAq1NYF60Jdq4Wu1rpVK7a0alv1p0Wt1gVXpK6oKFqX1o1dZF8ia1hkByHrzLy/P+YmTJKZyYRMMkvez/PwcOfOuWfOncydd85yzxFVxRhjjAkmKdoFMMYYE9ssUBhjjAnJAoUxxpiQLFAYY4wJyQKFMcaYkCxQGGOMCckChTFRICLLRGRktMthTDjE7qMwxhgTitUojDHGhGSBwphGEpFuIvKaiOwQkV0i8g8R6S0iHzmPd4rICyLSzu+Y9SLyvWiW25hwWaAwphFExAW8DWwAegJdgWmAAH8BjgSOAroBd0WlkMY0UnK0C2BMnBuGLxjcpKpuZ99nzv9Fzv87ROR+4A/NXThjIsEChTGN0w3Y4BckABCRTsBDwMlAJr7a+57mL54xjWdNT8Y0ziagu4jU/tH1F0CBQaraFrgMX3OUMXHHAoUxjTMX2ArcIyIZIpIuIifiq0UcAPaKSFfgpmgW0pjGsEBhTCOoqgc4D+gDbASKgYuBScCxwD7gHeC1aJXRmMayG+6MMcaEZDUKY4wxIVmgMMYYE5IFCmOMMSFZoDDGGBNSQtxw17FjR+3Zs2e0i2GMMXFlwYIFO1U1p750CREoevbsyfz586NdDGOMiSsisiGcdNb0ZIwxJiQLFMYYY0KyQGGMMSakhOijCKSyspLi4mLKysqiXZS4lp6eTm5uLikpKdEuijEmShI2UBQXF5OZmUnPnj0RsUk7D4eqsmvXLoqLi8nLy4t2cYwxUZKwTU9lZWVkZ2dbkGgEESE7O9tqZca0cAkbKAALEhFg76ExJqxAISKjRWSViBSJyC0Bnk8TkZed5+eISE+/52519q8SkVH15SkiZ4jIQhFZJCKfiUifxp2iMSZerN1xgJfmbqSs0hPtohg/9QYKZ/H4KcDZQAFwiYgU1Ep2NbBHVfsADwD3OscWAOOAAcBo4BERcdWT56PApao6BHgR+H3jTjE+rV+/noEDBzbomMcee4xnn322QXlNnTqV/Px88vPzmTp16mGV1Zhw/N9/1nDuw5+yYdfBoGnueHMpt762hCufnkeF29uMpTOhhFOjGAYUqepaVa0ApgFja6UZC1R9y7wCnCG+NouxwDRVLVfVdfgWmx9WT54KtHW2s4Ath3dqLc/111/PFVdcEXb63bt3M2nSJObMmcPcuXOZNGkSe/bYss6maTw3ewNLN+/n+ucXBg0Cq7YdINWVxJdrd3HfeyubuYQmmHACRVd86wJXKXb2BUzjLDK/D8gOcWyoPK8BZopIMXA5cE+gQonIdSIyX0Tm79ixI4zTaF7r16/nqKOO4tprr2XAgAGcddZZlJaWArBo0SKGDx/OoEGDOP/886u/nBcsWMDgwYMZMWIEU6ZMqc7L4/Fw0003cdxxxzFo0CD++c9/BnzNu+66i7/97W8h8/I3a9YszjzzTDp06ED79u0588wzee+99yL5NpgW4s1Fm3nys3V4vcEXQiupcJPXMYMVW/fzxKdrg6a5fEQPLhvenSc/X8dXG+2HSywIZ3hsoN7M2p+GYGmC7Q8UoKry/DVwjqrOEZGbgPvxBY+aiVUfBx4HKCwsDLlM36S3lrF8y/5QSRqs4Mi2/OG8ASHTrFmzhpdeeoknnniCiy66iFdffZXLLruMK664gocffphTTz2VO++8k0mTJvHggw9y5ZVXVu+/6aZDSyw/+eSTZGVlMW/ePMrLyznxxBM566yzQg5ZDZaXv82bN9OtW7fqx7m5uWzevLmB74Rp6So9Xn718iJUobTCzcTT8+uk8XqVkgoPYwYfyepvv+OhD9dw3qAj6Z7dujqNqlJa6aF1qotffS+f/yzfzq2vLeGtn59Eiiuhx93EvHDe/WKgm9/jXOo2B1WnEZFkfE1Gu0McG3C/iOQAg1V1jrP/ZeCEsM4kBuXl5TFkyBAAhg4dyvr169m3bx979+7l1FNPBWD8+PH873//q7P/8ssvr87n/fff59lnn2XIkCEcf/zx7Nq1izVr1gR93VB5+Qu0DK6NcjINdaDMTdVH6YH/rAn4o6zU6ZzOSHNx53kFuJKEu99eXiNNWaUXVWiV6iIzPYW7xhSwctt3PPtlWPPWmSYUTo1iHpAvInnAZnyd0z+ulWYGMB74ErgA+EhVVURmAC+KyP3AkUA+MBdfTSNQnnuALBHpq6qrgTOBFY08x3p/+TeVtLS06m2Xy1Xd9BSIqgb9klZVHn74YUaNGlVj/+23384777wD+JqzwsnLX25uLp988kn14+LiYkaOHFnvcabl8HiV8U/NpU1aMg+OG0J6iqtOmoMVbgBuP+coHvvvN9z+xhJevf4EkpKkTprWqckckdWKn5+ez73vreSTVdsZ2a8T4Gt2AmjtvMaoAV04tW8OD36wmvMGH0GnzPQmPVcTXL01CqfPYSIwC9+X9nRVXSYid4vIGCfZk0C2iBQBvwFucY5dBkwHlgPvARNU1RMsT2f/tcCrIvI1vj6KwO0mcSorK4v27dvz6aefAvDcc89x6qmn0q5dO7Kysvjss88AeOGFF6qPGTVqFI8++iiVlZUArF69moMHDzJ58mQWLVpUI0gAIfPyN2rUKN5//3327NnDnj17eP/99+sEI9OyfbPjAJ8V7eS9Zdv40zvLA6YpqfDVFo5s14rbv38UX23cy7R5m2qmKT9UowC46qSe5HXM4O63lld3bFfl0zrV9/tVRLhrzADK3V7umWkd29EU1hQeqjoTmFlr351+22XAhUGOnQxMDidPZ//rwOvhlCteTZ06leuvv56SkhJ69erF008/DcDTTz/NVVddRevWrWt8YV9zzTWsX7+eY489FlUlJyeHN954I+RrBMvLX4cOHbjjjjs47rjjALjzzjvp0KFDhM7SJIL1O31DWYfldeD52RsZPeAITsrvWCPNwXKnJpDm4pyju/DyvE3cN2slZw/sQvuMVF8avxoFQFqyizvPLeDKZ+bxzBfruO6U3tXNU61SD9Va8jpmcO0peUz5+BsuOb47x/W0z2dUqGrc/xs6dKjWtnz58jr7zOGx9zIxlVa49RcvLdRHPi4KmuaNr4q1x81v67LN+3TkXz/WkX/9WMsq3TXSfLZmh/a4+W2ds3aXqqqu2LpPe936jt722uLqNHPX7dIeN7+tn67eUePYq56eqwV3vKvf7ivVrzbu0R43v63/Wb6tRpqD5ZU64s//0VEP/Fcr3Z7GnrbxA8zXML5jbSiBMS3Ul2t38eaiLdz73kpemrsxYJpSpzmofUYKfzivgHU7D/KvT9fVSFNdo3BqAv27tOWKET14ce5GlhTvq5kmrWYfxx3nFlDpUe55d2V1H4V/jcKXbzJ3nOvr2H5+tnVsR4MFCmNaqN0HKgDo3qE1f3x7OZt2l9RJU9Vv0CrFxch+nRg1oDMPf7SGzXtL66TJSDvUkv3rM/uSnZHKnTOWVg+NBchIrdna3bNjBtecnMdrX23m86KdwKHmKX+jB3bh5PyO/P2D1ez4rrwxp20OQ0IHCg0w/NM0jL2H8WvngXI89dwAB/DQJccgwG2vL6nz967db3DHub6Zdv7kN7S1qv8hw68m0DY9hVvO9nVsv7qwuE6tw9+E0/rQpW06Uz7+Jmiaqo7tskoP97xrHdvNLWEDRXp6Ort27bIvukZQZz2K9HQblhhvFhfv5YS/fMSPn5hNuTvwBHtVv/LzO7Xhd6P78+manby9eGuNNGWVHpIEUp0b3nLbt2biaX14d+k2Plm13ZePM6KpdVrNmsAPj+nK0B7tuefdlWzb55uqPiOtbm0hIy2ZW8/pX+NxIL1z2nD1Sb14dWExCzbsrvc9MJGTsAsX5ebmUlxcTCxO7xFPqla4M/Hly292UeHxMmfdbv4ycyV3jal7L9FBv2aly4b34JUFxfzx7eWc2i+Htum+FQ1LKjy0SnHVuC/n2lN68drCzfxhxjJm/Sq7ukbRqtY9FklJwqQxAxjzj8/4+wergcC1BYAxg4/kl9N8w7zbBGh6qvLz0/vw5qLN3PHGMt76+Um4kuwG0eaQsIEiJSXFVmUzLVZVELhiRA+e+WI95xx9BMPyag4tLa1w0yrFVX1j3OTzBzJ2yufc//7q6sBSWumhVa0v7rRkF5PGDuDyJ+fyz/+urQ4mgb60B3bN4tLje/Cc0wmdlhy4EUNE+Ozm0/i8aCdZrYMvu5uRlszt3z+KiS9+xQtzNnDFiJ7hvSGmURK26cmYlqwqCNw8uj/dOrTi5lcX11njoaTCU+MX/qDcdlw+vAfPfrm+erRSWYWHVql1vyZOzs/h3EFHMOWTIlZs3V99I10gN57Vt3o71IwBue1bc/Fx3es9t+8ffQQn9M7mb7NWseuAdWw3BwsUxsSZZVv2ceb9/+XJz9YFTXPQCQIZacn85fxBrNt5kEc++aZGmpIKT52hqDee1Y8OGWnc/sYSPM5opdYpgRse7ji3gFRXEp+u2VknH3/tWqcy9aph3Hlu7WVsDo+IcPfYAZRUeLjXpiJvFhYojIkzMxZtYc32A/zx7eW8t3RbwDSlFZ7qexZOyu/I+cd05dFPiija/l11mpIKd53hqlmtUrjj3KNYXLyPF+dsoLTSQ3qQINC5bTq/PtNXW9i0O/g8ZgCn9s3hqpMi1xTcp1MmV5+Ux/T5xSy0qcibnAUKY+LMtv1ldG3XiqO7ZnHLa4vZvr+sTpqSCneNmsDt3z+KjLRkbnttafWaEYFqFODrWD6xTzb3zVrFpt0ltEoJ/jUxfkQPurZrxWn9ciJwZg3z8zPy6dw2jTvfXBpyGLBpPAsUxsSZ0goPmenJ/N+4IZRUeLjrrWV10tQOAh3bpHHb2Ucxd/1u/r1gU3WaYPcs/HHsQMorvazdeTDgDXBVkl1JfHjjqTx62dAInFnDtElL5vbvF7B08/6gd5abyLBAYUyMqe/eH99IJBe9ctrwyzPymblkGx8s/7ZGmpIKT50O5gsLcxmW14E/z1zJzgPlTqAIHAR65bTh+pG9AVixNfSiX+kproDTjzeH8wYdwYhe2fx11ip2H6yIShlaAgsUxsSQj1dtZ+AfZjHl46KgaUqd4agA153Si/5dMrnjjaV8V1ZZncY3ZLVmEBAR/nz+QEoq3Pzp7eW+5qkQndA/G9mb3PatuPT4+kciRYuIMGnsAA6Wu/nrLOvYbioWKIyJIW8t2sLBCg9/nbWKNxcFXpa2arlQgBRXEn/54dF8+10Zf5216lCaIEGgT6dMbhjZhzcWbWHDrpKQw1rTU1x8+rvTAi5tGkv6ds7kJyf0ZNq8TXy9aW+0i5OQLFAYE0MOlLvp06kNx3Zvx+/fWFpj8r0qpZWeGk09x3Rvz/gRPXlu9obqqS0OBmh6qvKzkb3p1TEDgKR6VkKMl6Vxf/m9fDq2SeMO69huEhYojIkhpZW+juoHLh6C16v87pWv607U59f0VOWmUf04MqsVv3vFd2NdaYCmpyrpKS7+dP5AwHeXdSLITE/h99/3Det97sv10S5OwrFAYUwMqRqJ1CM7g1vPOYrPi3bxcq1lRf2bnqpkpCXz5x8ezTc7DjLl46J6+x9O6N2RadcN55ffi+1mpYYYM/hITumbw32zVlG8p+6U6ebwWaAwppm4PV4WF+/F7fEGTePfCf3jYd0Z3qsDk99ZwdZ9h5qgSisC3wR3at8cfnhsVx7+qAiv1l0kqLbhvbLJahV8XqV4U9VZD3Db60tt5ugICitQiMhoEVklIkUickuA59NE5GXn+Tki0tPvuVud/atEZFR9eYrIpyKyyPm3RURCLw5tTJx46KMixvzjc657bkHQYOHfCZ2UJNz7o0G4vcptr/nWivB6lXK3t07TU5U7vl9AVbdCojQrNURu+9b8blQ//rd6B69/FXgwgGm4egOFiLiAKcDZQAFwiYjUnrTlamCPqvYBHgDudY4tAMYBA4DRwCMi4gqVp6qerKpDVHUI8CXwWuNP05joq+po/mjl9qBzFNW+Ca5HdgY3jerHx6t8X3xl7kNTgwfSPiOVv14w2LcdYhbWRHb5iJ4c270dd7+9nJ02aWBEhFOjGAYUqepaVa0ApgFja6UZC0x1tl8BzhDfcImxwDRVLVfVdUCRk1+9eYpIJnA6YDUKkxC27Svj7IFduGx4d574dB1fOEt/+isNMK3G+BN6MrRHeya9tZwNu3xt76H6Hy4YmsvbPz+JsUO6RvYE4oTLqYmVlHuY9Nby+g8w9QonUHQF/HvTip19AdOoqhvYB2SHODacPM8HPlTVgLeFish1IjJfRObb4kQmHpRVemmV6uL2cwro1TGD3/77a/b73SSnqpQE6Kh2JQn3XTCI0koPN07/GqDeO6EHds1q0Yv65HfOZMJpfXjr6y18uOLb+g8wIYUTKAJ92mr3EgVL09D9/i4BXgpWKFV9XFULVbUwJ6f5JyQzpqHKnPsfWqW6uP/iIXz7XTmTZhz6xVvh8eLxasBpNXrntOE3Z/ZluTOdRqhpvY3PDSN7069zJr+vdde6abhwAkUx0M3vcS6wJVgaEUkGsoDdIY4NmaeIZONrnnonnJMwJh6UVR66/2FIt3b8bGRvXl1YzPvLfFOFV609Haz/4ZqT8kh1VogL1fRkfFKTk7jnR0ezbX8Zf55p03s0RjiBYh6QLyJ5IpKKr3N6Rq00M4DxzvYFwEfqG5s2AxjnjIrKA/KBuWHkeSHwtqrWnT/ZmBi0dV8p9723kvU7DwZNU+b2ku43ZffPT8+n4Ii23Pb6EnYdKKfEWYEuWBBIdiXxzs9P4sQ+2Qw8MiuyJ5CgjunenmtP7sVLczfy39XWRH246g0UTp/DRGAWsAKYrqrLRORuERnjJHsSyBaRIuA3wC3OscuA6cBy4D1ggqp6guXp97LjCNHsZEyseeCD1TzyyTdc8NgXbNxV92avSqdZKd1vyGpqchL3XzyY/aVufv/GUkor3EDoZqX8zpm8cM1wOrVNj/xJJKjfnNmXPp3acPMri9lXak1QhyOs+yhUdaaq9lXV3qo62dl3p6rOcLbLVPVCVe2jqsNUda3fsZOd4/qp6ruh8vR7bqSqvheZUzSm6RXvKaV96xQq3F6uf35BnfWpS53HtYNA/y5t+fWZfXl36TZemusb3xFq/QfTcOkpLu6/aDA7DpQzKcDaHaZ+dme2MRFQWulhYNcsHhw3hOVb9/OXmStqPF8VONIC9D9cd0ovhvZoX70GtvU/RN6g3HZMGNmb1xZuru4TMuGzQGFMBJRW+EY0nd6/M1eflMfULzfw8crt1c+XV/ruxE5PrnvJuZKEv184uPpxRprVKJrCRL8+IVvkqGEsUBgTAf4T9d00qh/9u2Ry0ytfs+M7353BZUGanqr07JjBXecVkOISjsyy/oemkJqcxN8vGsy+0krueHNptIsTVyxQGBMB/lN/p6e4eOiSY/iuzF09TXhVH0V6iPmXfnJiHkvuGmUd1U3oqCPa8qvv9eWdxVt56+vao/xNMBYojImA2lNv9O2cyW3nHMXHq3bw3OwNlDlNT/XdKBettadbkp+e0ovB3dpxx5tL2bbPRuCHwwKFMfVYv/MgE15YyLtLtgZNU1pZdzGhK0b04LR+OUx+ZwVLNu8DqHEfhYmOZFcSD1w0mPJKLzf+exFeWxGvXvapNaYez8/ewDtLtnLDCwuZEaC5otLjxe3VOoFCRLjvgsG0SUvmj2/7puqwGkNs6JXThj+cV8DnRbuqR5uZ4CxQGFOPNdsP0KdTG4bldeCmf3/N8i0156ksqQjeUZ2TmcZ9Fwyqfhxseg7T/C4+rhujBnTmvlkrWerU+ExgFiiMqce+0kqOyErnkUuPJatVChNeXFhjkrn6RjSdcVRnTu/fCYD2rVObvsAmLCLCPT8cRIeMVH457StKKzz1H9RCWaAwph5lztDXjm3SePiSY9i4u4RbnRXn4FCNItSNck9cUch/bxpJ+wwLFLGkfUYq9180hG92HGTyTFu7IhgLFMbUo8Rv6OvxvbK58ay+vL14Ky/O3QhQ/Us0VLOSK0nokZ3R9IU1DXZin45cd0ovnp+9kQ+W29oVgVigMKYepZU1h75ef0pvTu2bw6S3lrNsy75D90hY/0PcuvGsvhQc0ZabX13M9v02ZLY2CxTG1KOswkOrlEPTaiQlCfdfNJj2rVOY+OJX1Xdf22R+8Sst2XeTZEmFm1+9vAiPDZmtwQKFMSFULU/aKrXmpZLdJo2Hxh3Dhl0HuXH6IsBGNMW7Pp3acPfYgXzxzS4e/mhNtIsTUyxQmBbN61VenLOxxgR+/io9iifAPRLg66/49ff6cjDE8FgTXy4cmssPj+nK/324hi+Kdka7ODHDAoVp0Wav3cVtry/hymfm8egn39R5vr7+h5+d1ofObdMAyGqV0nQFNc1CRPjjDwbSq2MGv5i2iO3fWX8FWKAwLdxi50ar0/rlcO97K3njq801ni93B19HAnyjmd7/9ak89ZNCcjLTmrawpllkpCXzyKVDOVBeya+tvwKwQGFauH2llaS6knj8ikKG5XXg5lcX17hLt8Ltm8wvzRX8UslqlcLp/Ts3eVlN8+nXJZO7xwzk86JdTPm4KNrFiToLFKZFKyl30zrNRYoriSk/PpYOGan89LkF1QvbVAWK1AALDpnEdmFhLucf05UH/7OaL75p2f0VYX36RWS0iKwSkSIRuSXA82ki8rLz/BwR6en33K3O/lUiMqq+PMVnsoisFpEVIvKLxp2iMcEdrPCQ4QxrzclM47HLhrLjQDk/f2khbo+XCo8FipZKRPjTDwbSs2MGv5y2qEXfX1Hvp19EXMAU4GygALhERApqJbsa2KOqfYAHgHudYwuAccAAYDTwiIi46snzJ0A3oL+qHgVMa9QZGhNCSYWbjLRD/Q+Du7Vj8g98TQ73zVp1qOnJAkWLlJGWzKOXDuVAmZufvbCw+vPQ0oTz6R8GFKnqWlWtwPfFPbZWmrHAVGf7FeAMERFn/zRVLVfVdUCRk1+oPG8A7lZVL4CqBh63aEwEHCj31LlR7sLCblwxogeP/28try30dW5bjaLl6tclk/suGMT8DXuY/E7LnA8qnE9/V2CT3+NiZ1/ANKrqBvYB2SGODZVnb+BiEZkvIu+KSH6gQonIdU6a+Tt27AjjNIypq6TcHXAyv99/v4DCHu155ov1AKSG6Mw2ie+8wUdy7cl5TP1yA68tLI52cZpdOJ9+CbCv9nixYGkauh8gDShT1ULgCeCpQIVS1cdVtVBVC3NycgIW3Jj6lLu9Ae+RSE1O4pHLjq1+bDfTmZtH92d4rw7c+tqSFrd+RTiBohhfn0GVXKD2Ml/VaUQkGcgCdoc4NlSexcCrzvbrwCCMaSIVbi8prkC/W6BTZjpvTjiRMws606dTm2YumYk1ya4k/uGMjLv++QXsLamIdpGaTTiBYh6QLyJ5IpKKr3N6Rq00M4DxzvYFwEfqm6x/BjDOGRWVB+QDc+vJ8w3gdGf7VGD14Z2aMTBr2TZueH4BX23cE/D5Co+X1OTgtYXB3drxxBWFNuGfAaBjmzQeufRYtu8v5xfTWs7NePUGCqfPYSIwC1gBTFfVZSJyt4iMcZI9CWSLSBHwG+AW59hlwHRgOfAeMEFVPcHydPK6B/iRiCwB/gJcE5lTNS3RX2au4N2l27j48dl8vKruuIgKt9f6H0yDHNO9PZPGDuB/q3fwt/dXRbs4zSKsn0mqOhOYWWvfnX7bZcCFQY6dDEwOJ09n/17g++GUy5hQyio9rN9VwpUn9mTe+t387PmFvPzT4QzKbVedptzttRFNpsEuGdadxcX7ePSTb+jXOZMfHFN7fE9isSvEJKzvytwA9OqYwdM/GUZ2m1SuemY+m3aXVKep9HjtHglzWCaNGcDxeR343auLgzZtJgq7QkzCKqnwBYrWqcnkZKbxzJXHUeH2cNUz89hfVgmE7sw2JpTU5CQeu2woXdqmc+2zC9iytzTaRWoyFihMwjpY7pv5terO6z6dMnnssqGs23mQCS8spNKZosOanszhap+Ryr/GF1JW6eHaZ+dX/zhJNHaFmIR10LloM9IOdcWd0Kcjf/7h0Xy6Zie/f30pHq+S6rJ7JMzh69s5k4cuGcLyrfu5cfrXeBNwJJQFCpOwDpYfanryd1FhN342sjcvz/dNDmA1CtNYp/fvzG1nH8W7S7fx4IeJt4yqXSEmYZU5q9MFWsb0t2f147R+vjv6rY/CRMI1J+dxwdBcHvpwTZ0FsOKd3UVkElZ5iLUkkpKERy8bypOfrWPM4CObu2gmAYkIk88fSPGeEm565Ws6tU3jhN4do12siLAahUlYlR5fW3GwG+rSU1xMOK0PndqmN2exTAJLS3bxz8sK6ZGdwU+fW8Dqb7+LdpEiwgKFSVi2Op2JhqzWKTxz5XGkp7i48ul5CbHgkV1BJu4FG2VS4fb1UVigMM0tt31rnhp/HLsPVnDV1HnVAyvilV1BJm6pKj9+YjaDJr3PVGfdCH9VTU/WWW2i4ejcLKZcegzLt+xn4ou+pXXjlQUKE7c27Crhi2924fZ6+cOMZdzz7kp8kxb72HrXJtpO79+ZP/5gIB+v2sEdby6r8fmMJzbqycStXQd96wE8eulQPlz5LY/99xtap7r4xRm+RRGr+ihSkixQmOi59PgeFO8p5dFPviGnTSq/OatftIvUYBYoTNwqr7pPItXF3WMGUlrh5f4PVpORlszVJ+VR4fHN45SUZE1PJrp+N6ofuw9U8NBHRbRrncpVJ+VFu0gNYoHCxK0yp7M6PcVFUpJw74+OpqTCzR/fXk6bNJetNWFiRtU9FntLK7j77eW0z0jh/GNyo12ssNlVZOJWWaWvaSk9xfcxTnYl8eC4IZzaN4dbXlvCawuLSbH+CRMjkl1J/N+4YxjRK5ub/r2Yj1Z+G+0ihc2uIhO3qqboSPM6YWklAAAYU0lEQVRbyjQt2cVjlw3luJ4d2FNSyd6SymgVz5g60lNcPH7FUPofkckNzy9k3vrd0S5SWCxQmLhVu0ZRpVWqiyfHF3J01yxO6J0djaIZE1RmegrPXDmMru1acdUz81ixdX+0i1QvCxQmblXVKNKT6076l5mewoyJJ/LMlcOau1jG1KtjmzSevXoYGanJXP7kHIq2H4h2kUIKK1CIyGgRWSUiRSJyS4Dn00TkZef5OSLS0++5W539q0RkVH15isgzIrJORBY5/4Y07hRNoqqa9C89wOyw4OtAtHsoTKzKbd+aF649HhB+/MRs1u88GO0iBVXvVSQiLmAKcDZQAFwiIgW1kl0N7FHVPsADwL3OsQXAOGAAMBp4RERcYeR5k6oOcf4tatQZmoR1qI/CgoGJT71z2vDitcfj9vpmGfBfzz2WhHOFDQOKVHWtqlYA04CxtdKMBaY6268AZ4iIOPunqWq5qq4Dipz8wsnTmJDK3B5Sk5PsPgkT1/p2zuT5q4/nYIWHH/9rdkyuvR1OoOgKbPJ7XOzsC5hGVd3APiA7xLH15TlZRBaLyAMikhaoUCJynYjMF5H5O3bsCOM0TKIpr/SSbrUJkwAKjmzLc1cPY+/BSi7915yYm3E2nKss0M+12hOWBEvT0P0AtwL9geOADsDNgQqlqo+raqGqFubk5ARKYhJcWaUnaP+EMfFmUG47nrlqGN/uL+PH/5rDzgPl0S5StXACRTHQze9xLrAlWBoRSQaygN0hjg2ap6puVZ9y4Gl8zVSmBavqiwi03wKFSSRDe7Tn6Z8cR/GeEsY9PjtmahbhBIp5QL6I5IlIKr7O6Rm10swAxjvbFwAfqW+axBnAOGdUVB6QD8wNlaeIHOH8L8APgKWNOUET3x75pIj+d7zHRf/8kg27ao4KKav0Wke2STjH98rmmSuHsWVvKeMen822fdEPFvVeZU6fw0RgFrACmK6qy0TkbhEZ4yR7EsgWkSLgN8AtzrHLgOnAcuA9YIKqeoLl6eT1gogsAZYAHYE/ReZUTTyaPm8TndumsWrbd/xgyucs3Lin+rkyt9UoTGIa3iubZ68axvbvyrn48S/ZHOUObonX+dH9FRYW6vz586NdDBNhbo+Xvr9/lwmn9eFHx+Yy/um5fLu/jEcvHcpp/Tsx7vEv8XiVf19/QrSLakyT+GrjHq54ai5t01OYdt1wunVoHdH8RWSBqhbWl87q7SZmlVR68CpktUqhZ8cMXr3hBPp0asO1z87nzUWbKav0Wo3CJLRjurfnxWuGc6DczUX//JJ1UbopzwKFiVllFYfWmwDftAcvXTucoT3a86uXF7Fo094aEwIak4iOzs3ipWuHU+72cvE/v6Ro+3fNXgYLFCZmlVYtTORXa8hMT2HqVcM4o39nAMrdgUdEGZNICo5sy0vXDsercOFjX7K4eG+zvr4FChOzSirqBgrwze302GXH8tuz+jLhtD7RKJoxza5fl0xeuX4ErVOT+fETc5i9dlezvbYFChOzqmoU6al1m5eSXUlMPD2f4b1sGnHTclT11XXJSmf8U3P5cEXzLH5kgcLErLIgNQpjWrIuWelM/+kI+nbO5KfPLeArvyHjTcXWzDYxK1AfhTEGOmSk8uK1x/P87I0Mzm3X5K9ngcLErApnvYm0FKv4GlNbZnoKN4zs3SyvZVegiVkVHl+gSHHZx9SYaLIr0MSsSo9v1oBUCxTGRJVdgSZmVVqNwpiYYFegiVmHAoWtYGdMNFmgMDGrqjM72WoUxkSVXYEmZlkfhTGxwa5AE3WLNu3lxulf89zsDdW1CLCmJ2Nihd1HYaLuN9MXsXbHQV5dWMy0uRt56JJj6J3ThkqPFxFwJVmgMCaarEZhouq7skrW7jjITaP68c/Lh7JlbyljHv6MtxdvocLjJcWVhG9VXGNMtFiNwkTVrgMVAByRlc6oAV0YlJvFhBcWMvHFrwBsTWxjYoBdhSaqqu6+rlqA6IisVky7bgQ/OaEnAOV+fRbGmOgIK1CIyGgRWSUiRSJyS4Dn00TkZef5OSLS0++5W539q0RkVAPyfFhEDhzeaZl4UV7pCwSpfjWH1OQk7hozgMcuG8rfLhwcraIZYxz1Nj2JiAuYApwJFAPzRGSGqi73S3Y1sEdV+4jIOOBe4GIRKQDGAQOAI4H/iEhf55igeYpIIdD0UyKaqKvw+GaIDdTENHpgl+YujjEmgHBqFMOAIlVdq6oVwDRgbK00Y4GpzvYrwBni64EcC0xT1XJVXQcUOfkFzdMJTH8Ffte4UzPxoKppKdX6IoyJWeFcnV2BTX6Pi519AdOoqhvYB2SHODZUnhOBGaq6NVShROQ6EZkvIvN37NgRxmmYWGSBwpjYF87VGWhsooaZpkH7ReRI4ELg4foKpaqPq2qhqhbm5OTUl9zEqOo1JyxQGBOzwrk6i4Fufo9zgS3B0ohIMpAF7A5xbLD9xwB9gCIRWQ+0FpGiMM/FxKFyCxTGxLxwrs55QL6I5IlIKr7O6Rm10swAxjvbFwAfqao6+8c5o6LygHxgbrA8VfUdVe2iqj1VtSdQoqp9GnuSJnYdqlHYcqfGxKp6Rz2pqltEJgKzABfwlKouE5G7gfmqOgN4EnjO+fW/G98XP0666cBywA1MUFUPQKA8I396JtaVu32jnqyPwpjYFdad2ao6E5hZa9+dfttl+PoWAh07GZgcTp4B0rQJp3wmflXVKGyGWGNil12dJqqq+yhS7KNoTKyyq9NEldUojIl9dnWaqKpwe3Elia1iZ0wMs6vTRFW522O1CWNinF2hJqoq3F7rnzAmxtkVaqKq3O21GoUxMc6uUNNslm7ex5SPi5i9dhe++zF9NQq7h8KY2GYr3JlmsW1fGRc89gVlzvoTx/Vszx/OG0CZ20N6it2VbUwss0BhmsV/VnxLWaWXGRNP5OvifTz4wWrO+8dnqEK3Dq2iXTxjTAhW5zfNYuPuElKTkxh4ZBaXD+/BR78dyfgRPQHo3qF1dAtnjAnJahSmWXy7v4wubdNJSvLNMJ/VKoW7xgzgqhPzbNSTMTHOAoVpFqUVHloF6Ivonm21CWNinf2UM82izO0l3WoOxsQlu3JNsyiv9JBmo5uMiUsWKEyz8NUoLFAYE48sUJhmUV7pId1urDMmLtmVa5pFWaXdWGdMvLJAYZpFWaWXNKtRGBOX7Mo1zaLcpuowJm6FFShEZLSIrBKRIhG5JcDzaSLysvP8HBHp6ffcrc7+VSIyqr48ReRJEflaRBaLyCsiYutmJ4BKj5Jis8QaE5fqvXJFxAVMAc4GCoBLRKSgVrKrgT2q2gd4ALjXObYAGAcMAEYDj4iIq548f62qg1V1ELARmNjIczQxoNLjJcUl0S6GMeYwhPMTbxhQpKprVbUCmAaMrZVmLDDV2X4FOENExNk/TVXLVXUdUOTkFzRPVd0P4BzfCtDGnKCJDW6vkmyBwpi4FE6g6Aps8ntc7OwLmEZV3cA+IDvEsSHzFJGngW1Af+DhQIUSketEZL6IzN+xY0cYp2GiRVXxeJXkJGt6MiYehXPlBvoZWPtXfrA0Dd3v21C9EjgSWAFcHKhQqvq4qhaqamFOTk6gJCZGVHp8f1prejImPoUTKIqBbn6Pc4EtwdKISDKQBewOcWy9eaqqB3gZ+FEYZTQxrNLjW6wo2TqzjYlL4Vy584B8EckTkVR8ndMzaqWZAYx3ti8APlLfWpczgHHOqKg8IB+YGyxP8ekD1X0U5wErG3eKJtrcTo0iOclqFMbEo3qnGVdVt4hMBGYBLuApVV0mIncD81V1BvAk8JyIFOGrSYxzjl0mItOB5YAbmODUFAiSZxIwVUTa4mue+hq4IbKnbJpbpddXo7DhscbEp7DWo1DVmcDMWvvu9NsuAy4McuxkYHKYeXqBE8Mpk4kf7uo+CgsUxsQju3JNkzvUR2FNT8bEIwsUpsm5vTbqyZh4ZoHCNDl3VY3C7qMwJi7Zmtkm4jxe5eGP1rBgwx76dc6kh7MuttUojIlPFihMxL0wZwMP/mcN+Z3aMGfdbircvhpF61T7uBkTj+zKNRH32sLNHN01ixkTT+RAuZuPVm5n1bbvGJbXIdpFM8YcBgsUJqLKKj0sLt7LDSN7IyJkpqcwdkjtqcGMMfHEehdNRBXvKcWr0KeTLSNiTKKwQGEiatOeEgC6tW8d5ZIYYyLFAoWJqO37ywDokpUe5ZIYYyLFAoWJqO/K3ABkpqdEuSTGmEixQGEi6kC5L1C0SbNxEsYkCgsUJqIOlrtpleLCZVOKG5MwLFCYiDpQ7qZNutUmjEkkFihMRB0o91izkzEJxgKFiajSCg9pyfaxMiaR2BVtIsrj9doCRcYkGLuiTUS5vWoLFBmTYCxQmIjyeJVkG/FkTEIJK1CIyGgRWSUiRSJyS4Dn00TkZef5OSLS0++5W539q0RkVH15isgLzv6lIvKUiNidW3HE7VUbGmtMgqk3UIiIC5gCnA0UAJeISEGtZFcDe1S1D/AAcK9zbAEwDhgAjAYeERFXPXm+APQHjgZaAdc06gxNs3J7vLaSnTEJJpwrehhQpKprVbUCmAaMrZVmLDDV2X4FOENExNk/TVXLVXUdUOTkFzRPVZ2pDmAukNu4UzTNyWM1CmMSTjiBoiuwye9xsbMvYBpVdQP7gOwQx9abp9PkdDnwXqBCich1IjJfRObv2LEjjNMwzcHtVVvy1JgEE06gCHTVa5hpGrrf3yPA/1T100CFUtXHVbVQVQtzcnICJTFRYDUKYxJPOLfQFgPd/B7nAluCpCkWkWQgC9hdz7FB8xSRPwA5wE/DKJ+JIW6vWh+FMQkmnCt6HpAvInkikoqvc3pGrTQzgPHO9gXAR04fwwxgnDMqKg/Ix9fvEDRPEbkGGAVcoqrexp2eaW5uj9dqFMYkmHprFKrqFpGJwCzABTylqstE5G5gvqrOAJ4EnhORInw1iXHOsctEZDqwHHADE1TVAxAoT+clHwM2AF/6+sN5TVXvjtgZmybltvsojEk4Yc3epqozgZm19t3pt10GXBjk2MnA5HDydPbbjHJxzGN3ZhuTcKwx2USU74Y7+1gZk0jsijYRZVN4GJN4LFCYiKq0zmxjEo4FChNRVqMwJvFYoDAR5Ztm3D5WxiQSu6JNRFmNwpjEY4HCRIyq2hQexiQgCxQmYtxe33RdVqMwJrFYoDAR46kKFNZHYUxCsSvaRIzVKIxJTBYoTMR4PL5AYX0UxiQWCxQmYtxe32S/NteTMYnFAoWJmKqmJ6tRGJNYLFCYiLE+CmMSkwUKEzFVfRS2wp0xicWuaBMxldZHYUxCskBhIqb6PgqrURiTUOyKNhHjtuGxxiQkCxQmYqqHx1qgMCahhBUoRGS0iKwSkSIRuSXA82ki8rLz/BwR6en33K3O/lUiMqq+PEVkorNPRaRj407PNKfqUU/WR2FMQqk3UIiIC5gCnA0UAJeISEGtZFcDe1S1D/AAcK9zbAEwDhgAjAYeERFXPXl+DnwP2NDIczPNrNJdVaOwiqoxiSQ5jDTDgCJVXQsgItOAscByvzRjgbuc7VeAf4iIOPunqWo5sE5Eipz8CJanqn7l7GvMeYXl9teXMGfdblR9v4S16gml5mOok0ar02jNx/4HNfDYQGmonX+tPAPmG8nzqXEiodNUdWZnpofzsTLGxItwruiuwCa/x8XA8cHSqKpbRPYB2c7+2bWO7eps15dnSCJyHXAdQPfu3RtyaLUj27WiX+dMJ8Ma/1UHKv9wJfWlqX5eQhxTM0314xpxsdZz9RwbqEx1Xz/UMZE7n/zObTi6axbGmMQRTqAI9NO+9u/mYGmC7Q/UNhHgt3hwqvo48DhAYWFhg46tMuG0PodzmDHGtCjhNCYXA938HucCW4KlEZFkIAvYHeLYcPI0xhgTA8IJFPOAfBHJE5FUfJ3TM2qlmQGMd7YvAD5SXyP4DGCcMyoqD8gH5oaZpzHGmBhQb6BQVTcwEZgFrACmq+oyEblbRMY4yZ4Esp3O6t8AtzjHLgOm4+v4fg+YoKqeYHkCiMgvRKQYXy1jsYj8K3Kna4wxpqFEAw3TiTOFhYU6f/78aBfDGGPiiogsUNXC+tLZgHdjjDEhWaAwxhgTkgUKY4wxIVmgMMYYE1JCdGaLyA4Of26ojsDOCBYnUqxcDWPlahgrV8Mkarl6qGpOfYkSIlA0hojMD6fXv7lZuRrGytUwVq6GaenlsqYnY4wxIVmgMMYYE5IFCmdiwRhk5WoYK1fDWLkapkWXq8X3URhjjAnNahTGGGNCskBhjDEmpBYdKERktIisEpEiEbmlGV+3m4h8LCIrRGSZiPzS2X+XiGwWkUXOv3P8jrnVKecqERnVxOVbLyJLnDLMd/Z1EJEPRGSN8397Z7+IyENO2RaLyLFNUJ5+fu/JIhHZLyK/itb7JSJPich2EVnqt6/B74+IjHfSrxGR8YFeKwLl+quIrHRe+3URaefs7ykipX7v3WN+xwx1/v5FTtkbtS5xkHI1+G8X6es1SLle9ivTehFZ5Oxvzvcr2PdD9D5jqtoi/wEu4BugF5AKfA0UNNNrHwEc62xnAquBAnzrjv82QPoCp3xpQJ5TblcTlm890LHWvvuAW5ztW4B7ne1zgHfxrWY4HJjTDH+3bUCPaL1fwCnAscDSw31/gA7AWuf/9s52+yYo11lAsrN9r1+5evqnq5XPXGCEU+Z3gbOboFwN+ts1xfUaqFy1nv87cGcU3q9g3w9R+4y15BrFMKBIVdeqagUwDRjbHC+sqltVdaGz/R2+NTm6hjhkLDBNVctVdR1QhK/8zWksMNXZngr8wG//s+ozG2gnIkc0YTnOAL5R1VB34jfp+6Wq/8O3gmPt12zI+zMK+EBVd6vqHuADYHSky6Wq76tv/RfwrV+fGyoPp2xtVfVL9X3bPOt3LhErVwjB/nYRv15DlcupFVwEvBQqjyZ6v4J9P0TtM9aSA0VXYJPf42JCf1k3CRHpCRwDzHF2TXSqj09VVS1p/rIq8L6ILBCR65x9nVV1K/g+yECnKJVtHDUv3lh4v6Dh7080yngVvl+eVfJE5CsR+a+InOzs6+qUpTnK1ZC/XXO/XycD36rqGr99zf5+1fp+iNpnrCUHikDtiM06VlhE2gCvAr9S1f3Ao0BvYAiwFV/VF5q/rCeq6rHA2cAEETklRNpmK5v4ls0dA/zb2RUr71cowcrSrGUUkdsBN/CCs2sr0F1Vj8G3KuWLItK2GcvV0L9dc/9NL6HmD5Jmf78CfD8ETRqkDBErW0sOFMVAN7/HucCW5npxEUnB9yF4QVVfA1DVb9W3VKwXeIJDzSXNWlZV3eL8vx143SnHt1VNSs7/26NQtrOBhar6rVO+mHi/HA19f5qtjE4n5rnApU7zCE7Tzi5newG+9v++Trn8m6eapFyH8bdrzvcrGfgh8LJfeZv1/Qr0/UAUP2MtOVDMA/JFJM/5pToOmNEcL+y0fz4JrFDV+/32+7ftnw9UjcaYAYwTkTQRyQPy8XWgNUXZMkQks2obX2foUqcMVaMmxgNv+pXtCmfkxXBgX1X1uAnU+JUXC++Xn4a+P7OAs0SkvdPscpazL6JEZDRwMzBGVUv89ueIiMvZ7oXvPVrrlO07ERnufE6v8DuXSJaroX+75rxevwesVNXqJqXmfL+CfT8Qzc9YY3rn4/0fvtECq/H9Ori9GV/3JHxVwMXAIuffOcBzwBJn/wzgCL9jbnfKuYpGjqqop2y98I0o+RpYVvW+ANnAh8Aa5/8Ozn4BpjhlWwIUNlG5WgO7gCy/fVF5v/AFq61AJb5fbVcfzvuDr8+gyPl3ZROVqwhfO3XV5+wxJ+2PnL/v18BC4Dy/fArxfXF/A/wDZwaHCJerwX+7SF+vgcrl7H8GuL5W2uZ8v4J9P0TtM2ZTeBhjjAmpJTc9GWOMCYMFCmOMMSFZoDDGGBOSBQpjjDEhWaAwxhgTkgUKY4wxIVmgMMYYE5IFCmMiQHzrFawUkX+JyFIReUFEvicinztrAQwTkVPl0HoGX1XdAW9MrLMb7oyJAGeWzyJ8M30uwzflxNf47kIeA1yJb02Fe1T1c2fCtzI9NAW4MTHLahTGRM46VV2ivonulgEfqu+X2BJ8C998DtwvIr8A2lmQMPHCAoUxkVPut+31e+zFt8rcPcA1QCtgtoj0b+byGXNYkqNdAGNaChHprapLgCUiMgLoD6yMcrGMqZfVKIxpPr9yOrq/BkqpudqcMTHLOrONMcaEZDUKY4wxIVmgMMYYE5IFCmOMMSFZoDDGGBOSBQpjjDEhWaAwxhgTkgUKY4wxIf0/nh9t6Q5pU88AAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -685,21 +817,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I made changes to two files that simply added parentheses to the print statements to make compatible with Python 3. Then, I noticed the first tutorial in the /docs/tutorial folder didn't function properly any more. I updated two things there; (1) pprint does not work in Python 3 the way it did in Python 2 causing the output to be blank. I took out pprint and replaced it with print. (2) In 01_single_cell_clamped, when it came time to run the build_env_bionet function, there was an error which was fixed by adding an if statement to bmtk/bmtk/utils/sim_setup.py. Details are in the commit.