### PR TITLE
changed NMLLoad to loadHOC

### DIFF
--- a/bmtk/simulator/bionet/default_setters/cell_models.py
+++ b/bmtk/simulator/bionet/default_setters/cell_models.py
@@ -467,7 +467,7 @@ def set_extracellular(hobj, cell, dynamics_params):
     return hobj
 
 
-add_cell_model(NMLLoad, directive='hoc', model_type='biophysical')
+add_cell_model(loadHOC, directive='hoc', model_type='biophysical')
 add_cell_model(NMLLoad, directive='nml', model_type='biophysical')
 add_cell_model(Biophys1, directive='ctdb:Biophys1', model_type='biophysical', overwrite=False)
 add_cell_model(Biophys1, directive='ctdb:Biophys1.hoc', model_type='biophysical', overwrite=False)


### PR DESCRIPTION
We made this change because we like to use our own cell templates that are written in HOC. This allows them to be used without the need for additional work-arounds. I think this may have just been a typo or oversight in the original version. Should be backward compatible. 