### PR TITLE
updated current clamp 

### DIFF
--- a/bmtk/simulator/bionet/biosimulator.py
+++ b/bmtk/simulator/bionet/biosimulator.py
@@ -211,7 +211,7 @@ class BioSimulator(Simulator):
 
         for idx,gid in enumerate(gids):
             cell = self.net.get_cell_gid(gid)
-            Ic = IClamp(amplitude[idx], delay, duration)
+            Ic = IClamp(amplitude[idx], delay[idx], duration[idx])
             
             Ic.attach_current(cell)
             self._iclamps.append(Ic)
@@ -321,6 +321,20 @@ class BioSimulator(Simulator):
                 if len(sim_input.params['amp'])>1:
                     sim_input.params['amp']=[float(i) for i in sim_input.params['amp']]
 
+                try: 
+                    len(sim_input.params['delay'])
+                except:
+                    sim_input.params['delay']=[float(sim_input.params['delay'])]
+                if len(sim_input.params['delay'])>1:
+                    sim_input.params['delay']=[float(i) for i in sim_input.params['delay']]
+                
+                try: 
+                    len(sim_input.params['duration'])
+                except:
+                    sim_input.params['duration']=[float(sim_input.params['duration'])]
+                if len(sim_input.params['duration'])>1:
+                    sim_input.params['duration']=[float(i) for i in sim_input.params['duration']]
+                    
                 amplitude = sim_input.params['amp']
                 delay = sim_input.params['delay']
                 duration = sim_input.params['duration']

--- a/bmtk/utils/sim_setup.py
+++ b/bmtk/utils/sim_setup.py
@@ -384,8 +384,8 @@ class EnvBuilder(object):
             "node_set": "all",
             "gids": current_param['gids'],
             "amp": current_param['amp'],
-            "delay": float(current_param['delay']),
-            "duration": float(current_param['duration'])
+            "delay": current_param['delay'],
+            "duration": current_param['duration']
         }
 
         if 'inputs' not in self._simulation_config:


### PR DESCRIPTION
In a previous pull request, I updated the current clamp function such that the user could provide a list of gids and amplitudes so that different current clamp parameters could be applied to different cells. This extends that functionality so that delay and duration can also be lists. The "basic" usage, i.e. supplying floats will still work in the same way.