### PR TITLE
Added FileIClamp module with non-constant amplitude capability.

### DIFF
--- a/bmtk/simulator/bionet/iclamp.py
+++ b/bmtk/simulator/bionet/iclamp.py
@@ -36,3 +36,23 @@ class IClamp(object):
         self._stim.dur = self._iclamp_dur
         self._stim.amp = self._iclamp_amp
         return self._stim
+
+
+class FileIClamp(object):
+    def __init__(self, amplitudes, dt):
+        self._iclamp_amps = amplitudes
+        self._iclamp_dt = dt
+        self._stim = None
+
+    def attach_current(self, cell):
+        self._stim = h.IClamp(cell.hobj.soma[0](0.5))
+
+        #Listed as necessary values in the docs to use play() with an IClamp.
+        self._stim.delay = 0
+        self._stim.dur = 1e9
+
+        self._vect_stim = h.Vector(self._iclamp_amps)
+        self._vect_stim.play(self._stim._ref_amp, self._iclamp_dt)  #Plays the amps to the IClamp amp variable with a given dt.
+
+        return self._stim
+

--- a/bmtk/utils/sim_setup.py
+++ b/bmtk/utils/sim_setup.py
@@ -393,6 +393,24 @@ class EnvBuilder(object):
 
         self._simulation_config['inputs']['current_clamp'] = iclamp_config
 
+    def _add_file_current_clamp(self, current_param):
+        if current_param is None:
+            return
+
+        amp_file = os.path.abspath(current_param["input_file"])
+
+        f_iclamp_config = {
+            "input_type": "current_clamp",
+            "module": "FileIClamp",
+            "node_set": "all",
+            "input_file": amp_file
+        }
+
+        if 'inputs' not in self._simulation_config:
+            self._simulation_config['inputs'] = {}
+
+        self._simulation_config['inputs']['file_current_clamp'] = f_iclamp_config
+
     def _add_spikes_inputs(self, spikes_inputs):
         inputs_dict = {}
         for s in spikes_inputs:
@@ -426,7 +444,7 @@ class EnvBuilder(object):
         shutil.copy(os.path.join(self.examples_dir, run_script), os.path.join(self.base_dir, run_script))
 
     def build(self, include_examples=False, use_relative_paths=True, report_vars=[],
-              report_nodes=None, current_clamp=None, spikes_inputs=None, **run_args):
+              report_nodes=None, current_clamp=None, file_current_clamp=None, spikes_inputs=None, **run_args):
         self._parse_network_dir(self.network_dir)
         self._create_components_dir(self.components_dir, with_examples=include_examples)
         if use_relative_paths:
@@ -447,6 +465,10 @@ class EnvBuilder(object):
                 current_clamp['gids']='all'
 
         self._add_current_clamp(current_clamp)
+
+        if file_current_clamp is not None:
+            self._add_file_current_clamp(file_current_clamp)
+
         if spikes_inputs!=None:
             self._add_spikes_inputs(spikes_inputs)
         if use_relative_paths:
@@ -543,6 +565,7 @@ def build_env_bionet(base_dir='.', network_dir=None, components_dir=None, node_s
                      v_init=-80.0, celsius=34.0,
                      report_vars=[], report_nodes=None,
                      current_clamp=None,
+                     file_current_clamp=None,
                      spikes_inputs=None,
                      compile_mechanisms=False,
                      use_relative_paths=True):
@@ -551,7 +574,7 @@ def build_env_bionet(base_dir='.', network_dir=None, components_dir=None, node_s
 
     env_builder.build(include_examples=include_examples, use_relative_paths=use_relative_paths,
                       report_vars=report_vars, report_nodes=report_nodes, current_clamp=current_clamp,
-                      spikes_inputs=spikes_inputs,
+                      file_current_clamp=file_current_clamp, spikes_inputs=spikes_inputs,
                       tstart=tstart, tstop=tstop, dt=dt, dL=dL, spikes_threshold=spikes_threshold,
                       nsteps_block=nsteps_block, v_init=v_init, celsius=celsius)
 


### PR DESCRIPTION
I added a new input module with the name "file_current_clamp" that allows for the addition of IClamps with non-constant amplitudes. The only parameter that the user inputs to this module is a file location called "input_file." As of now, the file must be in .h5 format. This file has to contain a data set called "amplitudes," which should contain a 2D array of amplitudes. The first dimension of this array should have the same length as the number of gids. There are also two optional datasets within the .h5 file: "gids" and "dts." The gids dateset will be treated in the same manner as it is within the regular IClamp module. The dts data set contains how much time is in between each amplitude in the amplitude array. For example, if the dt was 1 for a specific cell, the amplitude array for that cell would be iterated through every one ms. If "dts" is not in the input file, it is automatically set to 1 (ms). The amplitude array and dt for each cell is then passed to a new class called FileIClamp which plays the passed in amplitude array to the NEURON IClamp. 

Here is an example of how someone might make an amplitude array consisting of some normal distribution:

They could first create some integers delay and duration.
Then, assuming their dt is 1 and delay and duration are in ms, they could make an amp array equal to np.zeros(delay + duration + 1).
After that, they can fill the array by using:
amp[delay:-1] = np.random.normal(mean, std, duration)
The reason an extra zero is added at the end of the amp array is that after the array has been played through, the amplitude will remain constant at whatever value it was last changed to.

In this case, it would be important that when the user puts the amp array in the h5 file, they pass it in as [amp] instead of just amp, so that it is a 2D array.
