### PR TITLE
Added gap junctions.

### DIFF
--- a/bmtk/simulator/bionet/biosimulator.py
+++ b/bmtk/simulator/bionet/biosimulator.py
@@ -66,7 +66,7 @@ class BioSimulator(Simulator):
 
         h.runStopAt = h.tstop
         h.steps_per_ms = 1/h.dt
-
+        pc.setup_transfer()#Sets up gap junctions.
         self._set_init_conditions()  # call to save state
         h.cvode.cache_efficient(1)
                
@@ -383,18 +383,20 @@ class BioSimulator(Simulator):
     def from_config(cls, config, network, set_recordings=True):
         # TODO: convert from json to sonata config if necessary
 
+        #The network must be built before initializing the simulator because
+        #gap junctions must be set up before the simulation is initialized.
+        network.io.log_info('Building cells.')
+        network.build_nodes()
+
+        network.io.log_info('Building recurrent connections')
+        network.build_recurrent_edges()
+
         sim = cls(network=network,
                   dt=config.dt,
                   tstop=config.tstop,
                   v_init=config.v_init,
                   celsius=config.celsius,
                   nsteps_block=config.block_step)
-
-        network.io.log_info('Building cells.')
-        network.build_nodes()
-
-        network.io.log_info('Building recurrent connections')
-        network.build_recurrent_edges()
 
         # TODO: Need to create a gid selector
         for sim_input in inputs.from_config(config):

--- a/bmtk/simulator/core/sonata_reader/edge_adaptor.py
+++ b/bmtk/simulator/core/sonata_reader/edge_adaptor.py
@@ -52,6 +52,13 @@ class SonataBaseEdge(object):
         return self._edge['distance_range']
 
     @property
+    def is_gap_junction(self):
+        try:
+            return self._edge['is_gap_junction']
+        except:
+            return False
+
+    @property
     def edge_type_id(self):
         return self._edge.edge_type_id
 
@@ -93,7 +100,7 @@ class EdgeAdaptor(object):
 
         for et_id in edge_type_ids:
             edge_type = edge_types_table[et_id]
-            if 'dynamics_params' in edge_types_table.columns:
+            if 'dynamics_params' in edge_types_table.columns and edge_type['dynamics_params'] != None:
                 dynamics_params = edge_type['dynamics_params']
                 params_dir = network.get_component('synaptic_models_dir')
 

--- a/bmtk/simulator/core/sonata_reader/network_reader.py
+++ b/bmtk/simulator/core/sonata_reader/network_reader.py
@@ -180,6 +180,10 @@ class SonataEdges(EdgesReader):
         for edge in self._edge_pop.get_target(node_id):
             yield self._edge_adaptors[edge.group_id].get_edge(edge)
 
+    def get_source(self, node_id):
+        for edge in self._edge_pop.get_source(node_id):
+            yield self._edge_adaptors[edge.group_id].get_edge(edge)
+
     def get_edges(self):
         for edge_group in self._edge_pop.groups:
             edge_adaptor = self._edge_adaptors[edge_group.group_id]

--- a/bmtk/utils/sim_setup.py
+++ b/bmtk/utils/sim_setup.py
@@ -149,6 +149,7 @@ class EnvBuilder(object):
         logger.info('Parsing {} for SONATA network files'.format(network_dir))
         net_nodes = {}
         net_edges = {}
+        net_gaps = {}
         for root, dirs, files in os.walk(network_dir):
             for f in files:
                 if not os.path.isfile(os.path.join(network_dir, f)) or f.startswith('.'):
@@ -181,7 +182,14 @@ class EnvBuilder(object):
                     edges_dict['edge_types_file'] = os.path.abspath(os.path.join(root, f))
                     net_edges[net_name] = edges_dict
                     logger.info('  Adding edge types file: {}'.format(edges_dict['edge_types_file']))
-
+                
+                elif '_gap_juncs' in f:
+                    net_name = f[:f.find('_gap_juncs')]
+                    gaps_dict = net_gaps.get(net_name, {})
+                    gaps_dict['gap_juncs_file'] = os.path.abspath(os.path.join(root, f))
+                    net_gaps[net_name] = gaps_dict
+                    logger.info('  Adding gap junctions file: {}'.format(gaps_dict['gap_juncs_file']))
+                    
                 else:
                     logger.info(
                         '  Skipping file (could not categorize): {}'.format(os.path.abspath(os.path.join(root, f))))
@@ -189,12 +197,15 @@ class EnvBuilder(object):
         if not (net_nodes or net_edges):
             logger.info('  Could not find any sonata nodes or edges file(s).')
 
-        network_config = {'nodes': [], 'edges': []}
+        network_config = {'nodes': [], 'edges': [], 'gap_juncs': []}
         for _, sect in net_nodes.items():
             network_config['nodes'].append(sect)
 
         for _, sect in net_edges.items():
             network_config['edges'].append(sect)
+
+        for _, sect in net_gaps.items():
+            network_config['gap_juncs'].append(sect)
 
         self._circuit_config['networks'] = network_config
 

--- a/bmtk/utils/sonata/config/sonata_config.py
+++ b/bmtk/utils/sonata/config/sonata_config.py
@@ -178,6 +178,7 @@ class SonataConfig(dict):
 
         self.nodes = self.networks.get('nodes', [])
         self.edges = self.networks.get('edges', [])
+        self.gap_juncs = self.networks.get('gap_juncs', [])
         self.with_networks = 'networks' in self and len(self.nodes) > 0
         self.spike_threshold = self.run.get('spike_threshold', -15.0)
         self.dL = self.run.get('dL', 20.0)


### PR DESCRIPTION
This pull request adds gap junction functionality to bmtk. The functionality is very simple, you just use this function in a very similar manner to adding regular edges:
`
net.add_gap_junctions(source={'pop_name': ['PyrA','PyrC']}, target={'pop_name': 'PyrA'},
                    resistance = 0.01, connection_rule=dist_conn_perc,
                    connection_params={'prob':0.30,'min_dist':0.0,'max_dist':300.0,'min_syns':1,'max_syns':2})
`

Some constraints are that the gap junctions must be between two cells on the same network builder and that if two different network builders are going to create their own gap junctions, a gj_id_start variable must be passed in to the second network builder, with a value greater than the number of gap junctions in all network builders that came before it.