### PR TITLE
Update biocell.py

### DIFF
--- a/bmtk/simulator/bionet/biocell.py
+++ b/bmtk/simulator/bionet/biocell.py
@@ -156,8 +156,8 @@ class BioCell(Cell):
         self._morph = morphology_obj
 
     def get_sections(self):
-        #return self._secs_by_id
-        return self._secs
+        return self._secs_by_id
+        #return self._secs
 
     def get_sections_id(self):
         return self._secs_by_id
@@ -167,7 +167,7 @@ class BioCell(Cell):
 
     def store_segments(self):
         self._segments = []
-        for sec in self._secs:
+        for sec in self._secs_by_id:
             for seg in sec:
                 self._segments.append(seg)
 


### PR DESCRIPTION
Methods "get_sections" and "store_segments" are used only in "MembraneReport". Both methods use variable "self._secs" which causes a problem that the membrane variables to be reported in each segment are repeated n times in the report if it belongs to a section with n segments. Using variable "self._secs_by_id" instead will solve the problem.
The intention to create "_secs" is to get the section to which a segment belongs. But "_secs" seems to be used only in line 254 and 318. Method "get_section" that indexes "_secs" by segment id seems not used anywhere. 
An alternative change is to replace "cell.get_sections()" by "cell.get_sections_id()" in line 128 of "bmtk/simulator/bionet/modules/record_cellvars.py". Then the methods "get_section" and "get_sections" of BioCell class here can be removed.