### PR TITLE
Fix two bugs in analyzer/spike_triains.py and utils/reports/spike_trains/spike_trains.py.

### DIFF
--- a/bmtk/analyzer/spike_trains.py
+++ b/bmtk/analyzer/spike_trains.py
@@ -136,7 +136,7 @@ def _plot_helper(plot_fnc, config_file=None, population=None, times=None, title=
     else:
         node_groups = None
 
-    plot_fnc(spike_trains=spike_trains, node_groups=node_groups, population=pop, times=times, title=title, show=show)
+    return plot_fnc(spike_trains=spike_trains, node_groups=node_groups, population=pop, times=times, title=title, show=show)
 
 
 def plot_raster(config_file=None, population=None, with_histogram=True, times=None, title=None, show=True,

--- a/bmtk/utils/reports/spike_trains/spike_trains.py
+++ b/bmtk/utils/reports/spike_trains/spike_trains.py
@@ -204,4 +204,4 @@ class PoissonSpikeGenerator(SpikeTrains):
 
 def _interpolate_fr(t, t0, t1, fr0, fr1):
     # Used to interpolate the firing rate at time t from a discrete list of firing rates
-    return fr0 + (fr1 - fr0)*(t - t0)/t1
+    return fr0 + (fr1 - fr0)*(t - t0)/(t1 - t0)


### PR DESCRIPTION
  - Fix wrong linear interpolation of firing rate in inhomogenous firing
    rate case.
  - Add missing keyword "return" in _plot_helper.