### PR TITLE
Ensuring NEURON 3d() functions target the correct section.

### DIFF
--- a/bmtk/simulator/bionet/default_setters/cell_models.py
+++ b/bmtk/simulator/bionet/default_setters/cell_models.py
@@ -354,20 +354,20 @@ def fix_axon_allactive_directed(hobj):
 
 def get_axon_direction(hobj):
     for sec in hobj.somatic:
-        n3d = int(h.n3d())  # get number of n3d points in each section
-        soma_end = np.asarray([h.x3d(n3d - 1), h.y3d(n3d - 1), h.z3d(n3d - 1)])
+        n3d = int(h.n3d(sec=sec))  # get number of n3d points in each section
+        soma_end = np.asarray([h.x3d(n3d - 1, sec=sec), h.y3d(n3d - 1, sec=sec), h.z3d(n3d - 1, sec=sec)])
         mid_point = int(n3d / 2)
-        soma_mid = np.asarray([h.x3d(mid_point), h.y3d(mid_point), h.z3d(mid_point)])
+        soma_mid = np.asarray([h.x3d(mid_point, sec=sec), h.y3d(mid_point, sec=sec), h.z3d(mid_point, sec=sec)])
 
     for sec in hobj.all:
         section_name = sec.name().split(".")[1][:4]
         if section_name == 'axon':
-            n3d = int(h.n3d())  # get number of n3d points in each section
+            n3d = int(h.n3d(sec=sec))  # get number of n3d points in each section
             axon_p3d = np.zeros((n3d, 3))  # to hold locations of 3D morphology for the current section
             for i in range(n3d):
-                axon_p3d[i, 0] = h.x3d(i)
-                axon_p3d[i, 1] = h.y3d(i)  # shift coordinates such to place soma at the origin.
-                axon_p3d[i, 2] = h.z3d(i)
+                axon_p3d[i, 0] = h.x3d(i, sec=sec)
+                axon_p3d[i, 1] = h.y3d(i, sec=sec)  # shift coordinates such to place soma at the origin.
+                axon_p3d[i, 2] = h.z3d(i, sec=sec)
 
     # Add soma coordinates to the list
     p3d = np.concatenate(([soma_mid], axon_p3d), axis=0)

--- a/bmtk/simulator/bionet/morphology.py
+++ b/bmtk/simulator/bionet/morphology.py
@@ -49,7 +49,7 @@ class Morphology(object):
         n3dsoma = 0
         r3dsoma = np.zeros(3)
         for sec in self.hobj.soma:
-            n3d = int(h.n3d())  # get number of n3d points in each section
+            n3d = int(h.n3d(sec=sec))  # get number of n3d points in each section
             r3d = np.zeros((3, n3d))  # to hold locations of 3D morphology for the current section
             n3dsoma += n3d
 
@@ -75,17 +75,17 @@ class Morphology(object):
         d1 = np.zeros(self.nseg)
 
         for sec in self.hobj.all:
-            n3d = int(h.n3d())  # get number of n3d points in each section
+            n3d = int(h.n3d(sec=sec))  # get number of n3d points in each section
             p3d = np.zeros((3, n3d))  # to hold locations of 3D morphology for the current section
             l3d = np.zeros(n3d)  # to hold locations of 3D morphology for the current section
             diam3d = np.zeros(n3d)  # to diameters
 
             for i in range(n3d):
-                p3d[0, i] = h.x3d(i) - p3dsoma[0]
-                p3d[1, i] = h.y3d(i) - p3dsoma[1]  # shift coordinates such to place soma at the origin.
-                p3d[2, i] = h.z3d(i) - p3dsoma[2]
-                diam3d[i] = h.diam3d(i)
-                l3d[i] = h.arc3d(i)
+                p3d[0, i] = h.x3d(i, sec=sec) - p3dsoma[0]
+                p3d[1, i] = h.y3d(i, sec=sec) - p3dsoma[1]  # shift coordinates such to place soma at the origin.
+                p3d[2, i] = h.z3d(i, sec=sec) - p3dsoma[2]
+                diam3d[i] = h.diam3d(i, sec=sec)
+                l3d[i] = h.arc3d(i, sec=sec)
 
             l3d /= sec.L                  # normalize
             nseg = sec.nseg


### PR DESCRIPTION
I was creating a cell model and came across an error in the following code:

https://github.com/AllenInstitute/bmtk/blob/022c24f6a3f318b66d1f9e1501bef1ed2741e1ef/bmtk/simulator/bionet/morphology.py#L51-L57

where the `h.x3d(i, sec=sec)` goes out of bounds. This was caused by the `h.n3d()` not accessing the correct section. When no `sec` is provided, NEURON uses a default section, and in this case, it was incorrect. Therefore, I went through bmtk and filled in `sec=sec` for these situations. This may not be necessary in all cases, but I think this is a situation where it is better to be safe than sorry.