### PR TITLE
adding compression for spikes/rates outputs

### DIFF
--- a/bmtk/simulator/bionet/modules/record_spikes.py
+++ b/bmtk/simulator/bionet/modules/record_spikes.py
@@ -38,7 +38,7 @@ class SpikesMod(SimulatorMod):
     """
 
     def __init__(self, tmp_dir, spikes_file_csv=None, spikes_file=None, spikes_file_nwb=None, cache_to_disk=True,
-                 spikes_sort_order=None, mode='a'):
+                 spikes_sort_order=None, mode='a', compression='gzip'):
         # TODO: Have option to turn off caching spikes to csv.
         def _file_path(file_name):
             if file_name is None:
@@ -72,6 +72,7 @@ class SpikesMod(SimulatorMod):
 
         cache_name = os.path.basename(self._h5_fname or self._csv_fname or self._nwb_fname)
         self._spike_writer = SpikeTrains(cache_dir=tmp_dir, cache_name=cache_name, cache_to_disk=cache_to_disk)
+        self._spike_writer.compression = compression
 
         self._gid_map = None
 
@@ -101,7 +102,8 @@ class SpikesMod(SimulatorMod):
             pc.barrier()
 
         if self._save_h5:
-            self._spike_writer.to_sonata(self._h5_fname, sort_order=self._sort_order, mode=self._mode)
+            self._spike_writer.to_sonata(self._h5_fname, sort_order=self._sort_order, mode=self._mode,
+                                         compression=self._spike_writer.compression)
             pc.barrier()
 
         if self._save_nwb:

--- a/bmtk/simulator/filternet/filtersimulator.py
+++ b/bmtk/simulator/filternet/filtersimulator.py
@@ -159,13 +159,14 @@ class FilterSimulator(Simulator):
 
         rates_csv = config.output.get('rates_csv', None)
         rates_h5 = config.output.get('rates_h5', None)
+        compression = config.output.get('compression', 'gzip')
         if rates_csv or rates_h5:
-            sim.add_mod(mods.RecordRates(rates_csv, rates_h5, config.output_dir))
+            sim.add_mod(mods.RecordRates(rates_csv, rates_h5, config.output_dir, compression=compression))
 
         spikes_csv = config.output.get('spikes_csv', None) or config.output.get('spikes_file_csv', None)
         spikes_h5 = config.output.get('spikes_h5', None) or config.output.get('spikes_file', None)
         spikes_nwb = config.output.get('spikes_nwb', None) or config.output.get('spikes_file_nwb', None)
         if spikes_csv or spikes_h5 or spikes_nwb:
-            sim.add_mod(mods.SpikesGenerator(spikes_csv, spikes_h5, spikes_nwb, config.output_dir))
+            sim.add_mod(mods.SpikesGenerator(spikes_csv, spikes_h5, spikes_nwb, config.output_dir, compression=compression))
 
         return sim

--- a/bmtk/simulator/filternet/modules/create_spikes.py
+++ b/bmtk/simulator/filternet/modules/create_spikes.py
@@ -11,7 +11,7 @@ from bmtk.utils.io.ioutils import bmtk_world_comm
 
 class SpikesGenerator(SimModule):
     def __init__(self, spikes_file_csv=None, spikes_file=None, spikes_file_nwb=None, tmp_dir='output',
-                 sort_order='node_id'):
+                 sort_order='node_id', compression='gzip'):
         def _get_file_path(file_name):
             if file_name is None or os.path.isabs(file_name):
                 return file_name
@@ -29,6 +29,7 @@ class SpikesGenerator(SimModule):
 
         self._h5_fname = _get_file_path(spikes_file)
         self._save_h5 = spikes_file is not None
+        self._compression = compression
 
         self._nwb_fname = _get_file_path(spikes_file_nwb)
         self._save_nwb = spikes_file_nwb is not None
@@ -57,7 +58,7 @@ class SpikesGenerator(SimModule):
             self._spike_writer.to_csv(self._csv_fname, sort_order=self._sort_order)
 
         if self._save_h5:
-            self._spike_writer.to_sonata(self._h5_fname, sort_order=self._sort_order)
+            self._spike_writer.to_sonata(self._h5_fname, sort_order=self._sort_order, compression=self._compression)
 
         if self._save_nwb:
             self._spike_writer.to_nwb(self._nwb_fname, sort_order=self._sort_order)

--- a/bmtk/simulator/filternet/modules/record_rates.py
+++ b/bmtk/simulator/filternet/modules/record_rates.py
@@ -10,7 +10,8 @@ from bmtk.utils.io.ioutils import bmtk_world_comm
 
 
 class RecordRates(SimModule):
-    def __init__(self, csv_file=None, h5_file=None, tmp_dir='output', sort_order='node_id'):
+    def __init__(self, csv_file=None, h5_file=None, tmp_dir='output', sort_order='node_id',
+                 compression='gzip'):
         self._tmp_dir = tmp_dir
         self._csv_file = csv_file if csv_file is None or os.path.isabs(csv_file) else os.path.join(tmp_dir, csv_file)
         self._save_to_csv = csv_file is not None
@@ -19,6 +20,11 @@ class RecordRates(SimModule):
         h5_file = h5_file if h5_file is None or os.path.isabs(h5_file) else os.path.join(tmp_dir, h5_file)
         self._save_to_h5 = h5_file is not None
         self._h5_file = h5_file
+        # make sure h5py is not confused with string 'none' or 'None'.
+        if isinstance(compression, str):
+            if compression.lower() == 'none':
+                compression = None
+        self._compression = compression
 
         self._sort_order = sort_order
         self._n_nodes = 0
@@ -69,9 +75,9 @@ class RecordRates(SimModule):
                     rates_grp = rates_h5.create_group('/firing_rates')
                     for pop, pop_table in self._firing_rates.items():
                         pop_grp = rates_grp.create_group(pop)
-                        pop_grp.create_dataset('node_id', data=self._node_ids[pop])
-                        pop_grp.create_dataset('times', data=self._timestamps)
-                        pop_grp.create_dataset('firing_rates_Hz', data=self._firing_rates[pop].T)
+                        pop_grp.create_dataset('node_id', data=self._node_ids[pop], compression=self._compression)
+                        pop_grp.create_dataset('times', data=self._timestamps, compression=self._compression)
+                        pop_grp.create_dataset('firing_rates_Hz', data=self._firing_rates[pop].T, compression=self._compression)
 
                 except Exception as e:
                     print(e)
@@ -94,9 +100,9 @@ class RecordRates(SimModule):
         with h5py.File(self._tmp_rates_path, 'w') as h5:
             for pop in self._firing_rates.keys():
                 pop_grp = h5.create_group(pop)
-                pop_grp.create_dataset('time', data=self._timestamps)
-                pop_grp.create_dataset('node_id', data=self._node_ids[pop])
-                pop_grp.create_dataset('firing_rates_Hz', data=self._firing_rates[pop])
+                pop_grp.create_dataset('time', data=self._timestamps, compression=self._compression)
+                pop_grp.create_dataset('node_id', data=self._node_ids[pop], compression=self._compression)
+                pop_grp.create_dataset('firing_rates_Hz', data=self._firing_rates[pop], compression=self._compression)
 
     def _combine_rates(self):
         n_cells = {}

--- a/bmtk/simulator/pointnet/modules/record_spikes.py
+++ b/bmtk/simulator/pointnet/modules/record_spikes.py
@@ -97,7 +97,7 @@ class SpikesMod(object):
     """
 
     def __init__(self, tmp_dir, spikes_file_csv=None, spikes_file=None, spikes_file_nwb=None, spikes_sort_order=None,
-                 cache_to_disk=True):
+                 cache_to_disk=True, compression='gzip'):
         def _get_path(file_name):
             # Unless file-name is an absolute path then it should be placed in the $OUTPUT_DIR
             if file_name is None:
@@ -125,6 +125,7 @@ class SpikesMod(object):
         self._spike_writer.delimiter = '\t'
         self._spike_writer.gid_col = 0
         self._spike_writer.time_col = 1
+        self._spike_writer.compression = compression
         self._sort_order = sort_order.none if not spikes_sort_order else sort_order_lu[spikes_sort_order]
 
         self._spike_detector = None
@@ -147,7 +148,8 @@ class SpikesMod(object):
 
         if self._h5_fname is not None:
             # TODO: reimplement with pandas
-            self._spike_writer.to_sonata(self._h5_fname, sort_order=self._sort_order)
+            self._spike_writer.to_sonata(self._h5_fname, sort_order=self._sort_order,
+                                         compression=self._spike_writer.compression)
             # io.barrier()
 
         if self._nwb_fname is not None:

--- a/bmtk/simulator/utils/simulation_reports.py
+++ b/bmtk/simulator/utils/simulation_reports.py
@@ -170,6 +170,7 @@ class SpikesReport(SimReport):
     def from_output_dict(cls, output_dict):
         params = {
             'spikes_file': output_dict.get('spikes_file', None),
+            'compression': output_dict.get('compression', 'gzip'),
             'spikes_file_csv': output_dict.get('spikes_file_csv', None),
             'spikes_file_nwb': output_dict.get('spikes_file_nwb', None),
             'spikes_sort_order': output_dict.get('spikes_sort_order', None),

--- a/bmtk/utils/reports/spike_trains/spike_trains_api.py
+++ b/bmtk/utils/reports/spike_trains/spike_trains_api.py
@@ -144,16 +144,18 @@ class SpikeTrainsAPI(object):
         """
         raise NotImplementedError()
 
-    def to_sonata(self, path, mode='w', sort_order=SortOrder.none, **kwargs):
+    def to_sonata(self, path, mode='w', sort_order=SortOrder.none, compression='gzip', **kwargs):
         """Write current spike-trains to a sonata hdf5 file
 
         :param path:
         :param mode:
         :param sort_order:
+        :param compression: Compression algorithm for h5py's dataset_create. 'gzip' is default
+                            Only applied to h5 spike data.
         :param kwargs:
         :return:
         """
-        write_sonata(path=path, spiketrain_reader=self, mode=mode, sort_order=sort_order, **kwargs)
+        write_sonata(path=path, spiketrain_reader=self, mode=mode, sort_order=sort_order, compression=compression, **kwargs)
 
     def to_csv(self, path, mode='w', sort_order=SortOrder.none, **kwargs):
         """Write spikes to csv file


### PR DESCRIPTION
Compression capability is added for spike/rate h5 files.

The option can be given in the 'output' or 'report' section of the config files for bionet, pointnet, and filternet.
String values such as 'gzip', 'lzf', or 'none', or integer 0-9 (level for gzip) are accepted.

The default is 'gzip', and this option will be ignored if h5 file will not be saved.
Simple tests in test_sonata_adaptor.py are implemented, but tests for for the individual components (bionet, pointnet, and filternet) are not implemented. Let's discuss if more comprehensive tests are desired.