### PR TITLE
Fix error xstim_waveforms.py

### DIFF
--- a/bmtk/simulator/bionet/modules/xstim_waveforms.py
+++ b/bmtk/simulator/bionet/modules/xstim_waveforms.py
@@ -92,10 +92,10 @@ def stimx_waveform_factory(waveform):
         # if waveform_conf is str or unicode assume to be name of file in stim_dir
         # waveform_conf = str(waveform_conf)   # make consistent
         file_ext = os.path.splitext(waveform)
-        if file_ext == 'csv':
+        if file_ext[-1] == '.csv':
             return WaveformCustom(waveform)
 
-        elif file_ext == 'json':
+        elif file_ext[-1] == '.json':
             with open(waveform, 'r') as f:
                 waveform = json.load(f)
         else:


### PR DESCRIPTION
This is an issue I encountered a long time ago and just fixed in my own version but I figured I should mention here too. For me, the original code returns an error that this change fixes. According to the os.path.splitext documentation, this also makes more sense.