### PR TITLE
Making non-separable FilterNet faster

### DIFF
--- a/bmtk/simulator/filternet/lgnmodel/cursor.py
+++ b/bmtk/simulator/filternet/lgnmodel/cursor.py
@@ -1,7 +1,14 @@
 import numpy as np
 import scipy.signal as spsig
 from numba import njit, prange
-import mpi4py.MPI as MPI
+
+try:
+    from mpi4py import MPI
+    mpi_size = MPI.COMM_WORLD.Get_size()
+    numba_parallel = mpi_size == 1  # if there is only 1 thread, turn on numba parallel
+except ImportError:
+    numba_parallel = True  # If there is no MPI, turn on numba parallel
+
 
 from .utilities import convert_tmin_tmax_framerate_to_trange
 
@@ -98,9 +105,6 @@ class KernelCursor(object):
             self.cache[ti_offset] = result
             return result
 
-
-# if MPI is not used (number of process is 1), turn on parallel in numba
-numba_parallel = MPI.COMM_WORLD.Get_size() == 1
 
 # a faster version of the commented out part of the above class method.
 # results agree up to a round off error.

--- a/bmtk/simulator/filternet/lgnmodel/cursor.py
+++ b/bmtk/simulator/filternet/lgnmodel/cursor.py
@@ -87,7 +87,14 @@ class KernelCursor(object):
             # col_inds = self.kernel.col_inds[allowed_inds]
             # kernel_vector = self.kernel.kernel[allowed_inds] 
             # result = np.dot(self.movie[t_inds, row_inds, col_inds], kernel_vector)
-            result = fast_dot_product(self.movie.data, ti_offset, self.kernel.t_inds, self.kernel.row_inds, self.kernel.col_inds, self.kernel.kernel)
+            result = fast_dot_product(
+                self.movie.data,
+                ti_offset,
+                self.kernel.t_inds,
+                self.kernel.row_inds,
+                self.kernel.col_inds,
+                self.kernel.kernel,
+            )
             self.cache[ti_offset] = result
             return result
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'scipy',
         'scikit-image',  # Only required for filternet, consider making optional
         'sympy',  # For FilterNet
+        'numba',  # For FilterNet
         'pynrrd'   # For nrrd reader
     ],
     extras_require={


### PR DESCRIPTION
I rewrote one function with numba, and it makes non-separable FilterNet much faster.
With no MPI, it is >10x faster (using numba's parallelization). With MPI (with an 8-core CPU), it is ~40x faster.

This change makes numba a requirement for FilterNet, so let's discuss it at the meeting before merging it.