### PR TITLE
Made use of numba optional to prevent conflicts with NEST simulator

### DIFF
--- a/bmtk/tests/simulator/bionet/test_iclamp.py
+++ b/bmtk/tests/simulator/bionet/test_iclamp.py
@@ -9,11 +9,10 @@ import h5py
 
 try:
     from conftest import MORPH_DIR, load_neuron_modules
-except ModuleNotFoundError as mnfe:
+except (ModuleNotFoundError, ImportError)  as mnfe:
     from .conftest import MORPH_DIR, load_neuron_modules
-
+    
 from bmtk.simulator.bionet.modules import iclamp
-
 
 pc = h.ParallelContext()
 

--- a/bmtk/tests/simulator/bionet/test_morphology.py
+++ b/bmtk/tests/simulator/bionet/test_morphology.py
@@ -4,10 +4,7 @@ import numpy as np
 from collections import namedtuple
 from neuron import h
 
-try:
-    from conftest import *
-except ModuleNotFoundError as mnfe:
-    from .conftest import *
+from .conftest import *
 
 from bmtk.simulator.bionet.nrn import load_neuron_modules
 from bmtk.simulator.bionet.morphology import Morphology

--- a/bmtk/tests/simulator/bionet/test_virtualcell.py
+++ b/bmtk/tests/simulator/bionet/test_virtualcell.py
@@ -16,9 +16,9 @@ class NRNPythonObj(object):
 try:
     load_neuron_modules(mechanisms_dir='components/mechanisms', templates_dir='.')
     h.pysim = NRNPythonObj()
-    has_mechanism = True
+    has_postfadvanced = True
 except AttributeError as ae:
-    has_mechanism = False
+    has_postfadvanced = False
 
 
 class MockNode(object):
@@ -32,7 +32,7 @@ class MockSpikes(object):
     def get_times(self, node_id):
         return self.spikes
 
-
+@pytest.mark.skipif(not has_postfadvanced, reason="NEURON unable to run post_fadvanced mechanics")
 @pytest.mark.skipif(not has_mechanism, reason='Mechanisms has not been compiled, run nrnivmodl mechanisms.')
 @pytest.mark.skipif(not nrn_installed, reason='NEURON is not installed')
 @pytest.mark.parametrize('spike_times', [
@@ -62,6 +62,7 @@ def test_spiketrain(spike_times):
     assert(len(v) > 0)
 
 
+@pytest.mark.skipif(not has_postfadvanced, reason="NEURON unable to run post_fadvanced mechanics")
 @pytest.mark.skipif(not has_mechanism, reason='Mechanisms has not been compiled, run nrnivmodl mechanisms.')
 @pytest.mark.skipif(not nrn_installed, reason='NEURON is not installed')
 @pytest.mark.parametrize('spike_times', [

--- a/docs/autodocs/source/filternet.rst
+++ b/docs/autodocs/source/filternet.rst
@@ -127,3 +127,41 @@ Creates a spreading black field originating from the center.
 * frame_rate: frames per second
 * gray_screen_dur: duration of the initial grey screen (seconds)
 * t_looming: time of the looming movie (seconds).
+
+
+Optimizations Techniques
+------------------------
+The time required to generate spikes will depending on the number of cells in the network, the stimulus type, complexity of the cell-models; among
+other factors. The full simulation time can take a few seconds to a few hours. The following options may sometimes be utilized in order to 
+significantly speed up the process.
+
+
+Parallelization with MPI
+++++++++++++++++++++++++
+The `MPI <https://www.mpi-forum.org/docs/>`_ library allows the simulation to be parallelized across multiple processors and machines for use in an 
+HPC cluster or even on a single machine with multiple cores. FilterNet can take advantage of using MPI automatically. Modelers will need the following
+installed on their machine:
+* Either `OpenMPI <https://www.open-mpi.org/>`_ or `MPICH2 <https://www.mpich.org/>`_ 
+* `mpi4py <https://mpi4py.readthedocs.io/en/stable/>`_
+
+On most HPC clusters these will be already installed. For personal machines you can often install using either `pip install mpi4py` or 
+`conda install -c conda-forge mpi4py`. Then to run across <N> different cores execute your run_filternet.py script using
+
+```bash
+$ mpirun -n <N> python run_filternet.py config.json
+```
+
+Or if using a scheduler like slurm you can often use the `srun` command instead (instructions for scheduling parallel jobs on an HPC will vary depending
+on the institute).
+
+The results will be the same as if running FilterNet on a single core, the results stored in the same directory as specified in the config file.
+
+
+Numba
++++++
+You can also optimize FilterNet run-time using the `Numba <https://numba.pydata.org/>`_ python libary (with and without MPI). To install numba in your python
+environment:
+
+```bash
+$ pip install numba
+```

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'scipy',
         'scikit-image',  # Only required for filternet, consider making optional
         'sympy',  # For FilterNet
-        'numba',  # For FilterNet
+        # 'numba',  # For FilterNet
         'pynrrd'   # For nrrd reader
     ],
     extras_require={


### PR DESCRIPTION
Having numba installed by default was causing issues with the unit-tests and running the examples using NEST. For some reason that I haven't been able to figure out, importing numba causes the NEST library to seg-fault (at-least with the conda-forge build of 3.0-3.3).

Decided to make using numba in FilterNet optional, and if not installed will default back to the old dot-product implementation.