### PR TITLE
Fix error that random seed is not set when using SpikeGenerator(seed=0)

### DIFF
--- a/bmtk/utils/reports/spike_trains/spike_trains.py
+++ b/bmtk/utils/reports/spike_trains/spike_trains.py
@@ -114,7 +114,7 @@ class SpikeGenerator(SpikeTrains):
         if population is not None and 'default_population' not in kwargs:
             kwargs['default_population']= population
 
-        if seed:
+        if seed is not None:
             np.random.seed(seed)
 
         super(SpikeGenerator, self).__init__(units=output_units, **kwargs)


### PR DESCRIPTION
When using seed=0 for SpikeGenerator, random seed was not set.