### PR TITLE
Replace imports of distutils.

### DIFF
--- a/bmtk/analyzer/spikes_analyzer.py
+++ b/bmtk/analyzer/spikes_analyzer.py
@@ -24,8 +24,8 @@ import pandas as pd
 import numpy as np
 
 try:
-    from distutils.version import LooseVersion
-    use_sort_values = LooseVersion(pd.__version__) >= LooseVersion('0.19.0')
+    from packaging.version import Version
+    use_sort_values = Version(pd.__version__) >= Version('0.19.0')
 
 except:
     use_sort_values = False

--- a/bmtk/utils/compile_mechanisms/compile_mechanisms.py
+++ b/bmtk/utils/compile_mechanisms/compile_mechanisms.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from subprocess import call
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 
 logger = logging.getLogger(__name__)
@@ -28,4 +28,4 @@ def copy_modfiles(mechanisms_dir, cached_dir=None):
         cached_dir = os.path.join(local_path, '..', 'scripts/bionet/mechanisms')
 
     logger.info('Copying mod files from {} to {}'.format(cached_dir, mechanisms_dir))
-    copy_tree(cached_dir, mechanisms_dir)
+    copytree(cached_dir, mechanisms_dir, dirs_exist_ok=True)

--- a/bmtk/utils/create_environment/env_builder.py
+++ b/bmtk/utils/create_environment/env_builder.py
@@ -27,7 +27,7 @@ import numpy as np
 from subprocess import call
 from collections import OrderedDict
 import logging
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 from bmtk.utils.compile_mechanisms import copy_modfiles, compile_mechanisms
 
@@ -270,7 +270,7 @@ class EnvBuilder(object):
 
             if with_examples:
                 logger.info('  Copying files from {}.'.format(src_dir))
-                copy_tree(src_dir, trg_dir)
+                copytree(src_dir, trg_dir, dirs_exist_ok=True)
 
         # return components_config
         self._circuit_config['components'] = components_config

--- a/bmtk/utils/sim_setup.py
+++ b/bmtk/utils/sim_setup.py
@@ -29,7 +29,7 @@ from subprocess import call
 from optparse import OptionParser
 from collections import OrderedDict
 import logging
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 
 logger = logging.getLogger(__name__)
@@ -248,7 +248,7 @@ class EnvBuilder(object):
 
             if with_examples:
                 logger.info('  Copying files from {}.'.format(src_dir))
-                copy_tree(src_dir, trg_dir)
+                copytree(src_dir, trg_dir, dirs_exist_ok=True)
 
         # return components_config
         self._circuit_config['components'] = components_config


### PR DESCRIPTION
As reported in [Debian bug #1083070], the Python module distutils is going to be removed entirely from the upcoming Debian release, following the deprecation on Python side of the distutils module. Removal of distutils is causing test failures in bmtk though:

	Traceback:
	/usr/lib/python3.12/importlib/__init__.py:90: in import_module
	    return _bootstrap._gcd_import(name[level:], package, level)
	tests/simulator/filternet/test_filternet_movies.py:5: in <module>
	    from bmtk.utils.sim_setup import build_env_filternet
	/usr/lib/python3/dist-packages/bmtk/utils/sim_setup.py:32: in <module>
	    from distutils.dir_util import copy_tree
	E   ModuleNotFoundError: No module named 'distutils'

These changes replace copy_tree invocations by shutil.copytree, with the option to clobber existing directories by default, as otherwise the refusal of erasing the target directory will cause other test regressions.  The version sort invocation perusing LooseVersion is replaced by invocations of the bare packaging.version.Version.

[Debian bug #1083070]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1083070