### PR TITLE
Specifying Y-direction for FilterNet

### DIFF
--- a/bmtk/simulator/filternet/filtersimulator.py
+++ b/bmtk/simulator/filternet/filtersimulator.py
@@ -85,7 +85,8 @@ class FilterSimulator(Simulator):
             mv = ffm.full(t_max=self._tstop)
             self._movies.append(mv)
 
-        elif movie_type == 'graiting':
+        # elif movie_type == 'graiting':
+        elif movie_type in ['grating', 'graiting']:  # Misspelled in original code
             init_param_names = list(signature(GratingMovie.__init__).parameters.keys())
             create_param_names = list(signature(GratingMovie.create_movie).parameters.keys())
             init_params = FilterSimulator.find_params(init_param_names, **params)
@@ -94,8 +95,8 @@ class FilterSimulator(Simulator):
 
             create_params['gray_screen_dur'] /= 1000.0
             gm = GratingMovie(**init_params)
-            graiting_movie = gm.create_movie(t_min=0.0, t_max=self._tstop, **create_params)
-            self._movies.append(graiting_movie)
+            grating_movie = gm.create_movie(t_min=0.0, t_max=self._tstop, **create_params)
+            self._movies.append(grating_movie)
 
         elif movie_type == 'looming':
             init_params = FilterSimulator.find_params(['row_size', 'col_size', 'frame_rate'], **params)

--- a/bmtk/simulator/filternet/filtersimulator.py
+++ b/bmtk/simulator/filternet/filtersimulator.py
@@ -40,39 +40,37 @@ class FilterSimulator(Simulator):
         movie_type = movie_type.lower() if isinstance(movie_type, string_types) else 'movie'
         if movie_type == 'movie' or not movie_type:
             if 'data_file' in params:
-                m_data = None
-                if 'data_file' in params:
-                    m_data = np.load(params['data_file'])
-                elif 'data' in params:
-                    m_data = params['data']
-                else:
-                    raise Exception('Could not find movie "data_file" in config to use as input.')
+                m_data = np.load(params['data_file'])
+            elif 'data' in params:
+                m_data = params['data']
+            else:
+                raise Exception('Could not find movie "data_file" in config to use as input.')
 
-                # If file passed in is a npz compressed file then it is in a dictionary format and need to find
-                # the key-value pair containing the array
-                if isinstance(m_data, np.lib.npyio.NpzFile):
-                    try:
-                        for key in m_data:
-                            m_data = m_data[key]
-                            break
-                    except IndexError as ie:
-                        io.log_warning('Was unable to find array from compressed numpy matrix file.')
+            # If file passed in is a npz compressed file then it is in a dictionary format and need to find
+            # the key-value pair containing the array
+            if isinstance(m_data, np.lib.npyio.NpzFile):
+                try:
+                    for key in m_data:
+                        m_data = m_data[key]
+                        break
+                except IndexError as ie:
+                    io.log_warning('Was unable to find array from compressed numpy matrix file.')
 
-                # contrast_min, contrast_max = m_data.min(), m_data.max()
-                normalize_data = params.get('normalize', False)
-                if normalize_data:
-                    m_data = Movie.normalize_matrix(m_data, domain=normalize_data)
+            # contrast_min, contrast_max = m_data.min(), m_data.max()
+            normalize_data = params.get('normalize', False)
+            if normalize_data:
+                m_data = Movie.normalize_matrix(m_data, domain=normalize_data)
 
-                init_params = FilterSimulator.find_params(['row_range', 'col_range', 'labels', 'units', 'frame_rate',
-                                                           't_range'], **params)
-                self._movies.append(Movie(m_data, **init_params))
+            init_params = FilterSimulator.find_params(['row_range', 'col_range', 'labels', 'units', 'frame_rate',
+                                                       't_range', 'y_dir', 'flip_y'], **params)
+            self._movies.append(Movie(m_data, **init_params))
 
         elif movie_type == 'full_field':
             raise NotImplementedError
 
         elif movie_type == 'full_field_flash':
             init_params = FilterSimulator.find_params(['row_size', 'col_size', 't_on', 't_off', 'max_intensity',
-                                                       'frame_rate'], **params)
+                                                       'frame_rate', 'y_dir'], **params)
             init_params['row_range'] = range(init_params['row_size'])
             del init_params['row_size']
             init_params['col_range'] = range(init_params['col_size'])
@@ -99,7 +97,8 @@ class FilterSimulator(Simulator):
             self._movies.append(grating_movie)
 
         elif movie_type == 'looming':
-            init_params = FilterSimulator.find_params(['row_size', 'col_size', 'frame_rate'], **params)
+            init_params = FilterSimulator.find_params(['row_size', 'col_size', 'frame_rate',
+                                                       'y_dir'], **params)
             movie_params = FilterSimulator.find_params(['t_looming', 'gray_sceen_dur'], **params)
             lm = LoomingMovie(**init_params)
             looming_movie = lm.create_movie(**movie_params)

--- a/bmtk/simulator/filternet/lgnmodel/movie.py
+++ b/bmtk/simulator/filternet/lgnmodel/movie.py
@@ -6,11 +6,16 @@ from bmtk.simulator.filternet.io_tools import io
 
 class Movie(object):
     def __init__(self, data, row_range=None, col_range=None, labels=('time', 'y', 'x'),
-                 units=('second', 'pixel', 'pixel'), frame_rate=None, t_range=None, padding=False):
-        self.data = data
+                 units=('second', 'pixel', 'pixel'), frame_rate=None, t_range=None,
+                 padding=False, y_dir='down', flip_y=False):
+        if flip_y:
+            self.data = data[:, ::-1, :]
+        else:
+            self.data = data
         self.labels = labels
         self.units = units
-        self.padding=padding
+        self.padding = padding
+        self.y_dir = y_dir 
         assert(units[0] == 'second')
 
         if t_range is None:
@@ -44,6 +49,9 @@ class Movie(object):
         ax.plot(t_vals, y_vals)
         ax.set_ylim(y_vals.min()-np.abs(y_vals.min())*.05, y_vals.max()+np.abs(y_vals.max())*.05)
         
+        if self.y_dir == 'up':
+            ax.invert_yaxis()
+        
         if not xlabel is None:
             ax.set_xlabel(xlabel)
             
@@ -61,6 +69,8 @@ class Movie(object):
         ti = int(t*self.frame_rate)
         data = self.data[ti, :, :]
         plt.imshow(data, vmin=vmin, vmax=vmax, cmap=cmap)
+        if self.y_dir == 'up':
+            plt.gca().invert_yaxis()
         plt.colorbar()
         if show:
             plt.show()
@@ -98,6 +108,8 @@ class Movie(object):
             # TODO: Find a way to display a running clock as a x-label or title
             frame_img = ax.imshow(data[i, :, :], cmap=cmap, animated=True, vmin=vmin, vmax=vmax,
                                   extent=[self.col_range[0], self.col_range[-1], self.row_range[0], self.row_range[-1]])
+            if self.y_dir == 'up':
+                ax.invert_yaxis()
             title = ax.text(0.99, 0.000, "{:05.2f} s".format(times[i]),
                             size=plt.rcParams["axes.titlesize"],
                             horizontalalignment='right',
@@ -186,7 +198,7 @@ class Movie(object):
 # TODO: Instead of using subclasses, convert the following movie type to a Factory class/function that returns a Movie
 #   object
 class FullFieldMovie(Movie):
-    def __init__(self, f, rows, cols, frame_rate=24.0):
+    def __init__(self, f, rows, cols, frame_rate=24.0, y_dir='down'):
         if np.isscalar(rows):
             rows = np.arange(0, rows)
 
@@ -198,6 +210,7 @@ class FullFieldMovie(Movie):
         self.frame_size = (len(self.row_range), len(self.col_range))
         self._frame_rate = frame_rate
         self.f = f
+        self.y_dir = y_dir
         
     @property
     def frame_rate(self):
@@ -230,28 +243,29 @@ class FullFieldMovie(Movie):
         data[af, bf, cf] = self.f(t_range[af])
         
         return Movie(data, row_range=self.row_range, col_range=self.col_range, labels=('time', 'y', 'x'),
-                     units=('second', 'pixel', 'pixel'), frame_rate=self.frame_rate)
+                     units=('second', 'pixel', 'pixel'), frame_rate=self.frame_rate, y_dir=self.y_dir)
 
     def create_movie(self, t_max, t_min=0.0):
         return self.full(t_min=t_min, t_max=t_max)
 
 
 class FullFieldFlashMovie(FullFieldMovie):
-    def __init__(self, row_range, col_range, t_on, t_off, max_intensity=1, frame_rate=24):
+    def __init__(self, row_range, col_range, t_on, t_off, max_intensity=1, frame_rate=24, y_dir='down'):
         assert(t_on < t_off)
 
         def f(t):
             return np.piecewise(t, *zip(*[(t < t_on, 0), (np.logical_and(t_on <= t, t < t_off), max_intensity),
                                           (t_off <= t, 0)]))
 
-        super(FullFieldFlashMovie, self).__init__(f, row_range, col_range, frame_rate=frame_rate)
+        super(FullFieldFlashMovie, self).__init__(f, row_range, col_range, frame_rate=frame_rate, y_dir=y_dir)
 
 
 class GratingMovie(Movie):
-    def __init__(self, row_size, col_size, frame_rate=1000.0):
+    def __init__(self, row_size, col_size, frame_rate=1000.0, y_dir='down'):
         self.row_size = row_size  # in degrees
         self.col_size = col_size  # in degrees
         self.frame_rate = float(frame_rate)  # in Hz
+        self.y_dir = y_dir  # 'up' or 'down'
 
     def create_movie(self, t_min=0, t_max=1, gray_screen_dur=0, cpd=0.05, temporal_f=4, theta=45,
                      phase=0., contrast=1.0, degrees_per_pixel=None, row_size_new=None, col_size_new=None):
@@ -282,10 +296,17 @@ class GratingMovie(Movie):
 
         # Creates a drifting grating panel
         tt, yy, xx = np.meshgrid(time_range, self.row_range, self.col_range, indexing='ij')
-        theta_rad = np.pi*(180 - theta) / 180.
-        phase_rad = np.pi*(180 - phase) / 180.
+        # theta_rad = np.pi*(180 - theta) / 180.
+        # phase_rad = np.pi*(180 - phase) / 180.
+        if self.y_dir == 'up':
+            theta_rad = np.deg2rad(theta)
+        elif self.y_dir == 'down':
+            theta_rad = np.deg2rad(-theta)
+        else:
+            raise ValueError("y_dir must be 'up' or 'down'")
+        phase_rad = np.deg2rad(phase)
         xy = xx * np.cos(theta_rad) + yy * np.sin(theta_rad)
-        data = contrast*np.sin(2*np.pi*(cpd * xy + temporal_f *tt) + phase_rad)
+        data = contrast*np.sin(2*np.pi*(cpd * xy - temporal_f *tt) + phase_rad)
 
         # truncate
         if row_size_new != None:
@@ -297,21 +318,23 @@ class GratingMovie(Movie):
         if gray_screen_dur > 0:
             # just adding one or two seconds to gray screen so flash never "happens"
             m_gray = FullFieldFlashMovie(self.row_range, self.col_range, gray_screen_dur + 1, gray_screen_dur + 2,
-                                         frame_rate=self.frame_rate).full(t_max=gray_screen_dur)
+                                         frame_rate=self.frame_rate, y_dir=self.y_dir).full(t_max=gray_screen_dur)
             mov = m_gray + Movie(data, row_range=self.row_range, col_range=self.col_range, labels=('time', 'y', 'x'),
-                                 units=('second', 'pixel', 'pixel'), frame_rate=self.frame_rate)
+                                 units=('second', 'pixel', 'pixel'), frame_rate=self.frame_rate,
+                                 y_dir=self.y_dir)
         else:
             mov = Movie(data, row_range=self.row_range, col_range=self.col_range, labels=('time', 'y', 'x'),
-                        units=('second', 'pixel', 'pixel'), frame_rate=self.frame_rate)
+                        units=('second', 'pixel', 'pixel'), frame_rate=self.frame_rate, y_dir=self.y_dir)
 
         return mov
 
 
 class LoomingMovie(Movie):
-    def __init__(self, row_size, col_size, frame_rate=1000.):
+    def __init__(self, row_size, col_size, frame_rate=1000., y_dir='down'):
         self.row_size = row_size  # in degrees
         self.col_size = col_size  # in degrees
         self.frame_rate = float(frame_rate)  # in Hz
+        self.y_dir = y_dir
 
     def create_movie(self, t_looming=1, gray_screen_dur=0.5):
         """Create the looming movie with the desired parameters
@@ -341,6 +364,6 @@ class LoomingMovie(Movie):
         data *= -1   # Adjusting so have dark looming and not bright looming disk
 
         mov = Movie(data, row_range=self.row_range, col_range=self.col_range, labels=('time', 'y', 'x'),
-                    units=('second', 'pixel', 'pixel'), frame_rate=self.frame_rate)
+                    units=('second', 'pixel', 'pixel'), frame_rate=self.frame_rate, y_dir=self.y_dir)
 
         return mov

--- a/bmtk/tests/simulator/filternet/test_filternet_movies.py
+++ b/bmtk/tests/simulator/filternet/test_filternet_movies.py
@@ -8,7 +8,7 @@ from bmtk.utils.sim_setup import build_env_filternet
 def test_filtersimulator_add_movie_with_phase(tmp_path):
     simulator = build_simulator(tmp_path)
     simulator.add_movie(
-        'graiting',
+        'graiting',  # this is typo, but keeping it this line for backward compatibility
         {'row_size': 100,
          'col_size': 100,
          'gray_screen_dur': 0,
@@ -17,6 +17,21 @@ def test_filtersimulator_add_movie_with_phase(tmp_path):
         simulator._movies[0].data,
         GratingMovie(100, 100).create_movie(phase=180, t_max=simulator._tstop).data)
 
+def test_filtersimulator_add_movie(tmp_path):
+    simulator = build_simulator(tmp_path)
+    simulator.add_movie(
+        'grating',
+        {'row_size': 120,
+         'col_size': 80,
+         'gray_screen_dur': 0,
+         'y_dir': 'up'}
+    )
+    assert np.allclose(
+        simulator._movies[0].data,
+        GratingMovie(120, 80, y_dir='up').create_movie(
+            t_max=simulator._tstop
+        ).data,
+    )
 
 def build_simulator(tmp_path):
     data_dir = Path(__file__).parent / 'data' 

--- a/bmtk/tests/simulator/filternet/test_filternet_movies.py
+++ b/bmtk/tests/simulator/filternet/test_filternet_movies.py
@@ -19,19 +19,60 @@ def test_filtersimulator_add_movie_with_phase(tmp_path):
 
 def test_filtersimulator_add_movie(tmp_path):
     simulator = build_simulator(tmp_path)
+    theta = 9.59
     simulator.add_movie(
         'grating',
         {'row_size': 120,
          'col_size': 80,
+         'theta': theta,
          'gray_screen_dur': 0,
          'y_dir': 'up'}
     )
+    
+    sample_movie = GratingMovie(120, 80, y_dir='down').create_movie(
+        theta=theta,
+        t_max=simulator._tstop
+    )
+
+    # When y_dir is different, the movie should be different
+    assert not np.allclose(
+        simulator._movies[0].data,
+        sample_movie.data,
+    )
+
+    # When they match, they should be the same.
     assert np.allclose(
         simulator._movies[0].data,
         GratingMovie(120, 80, y_dir='up').create_movie(
+            theta=theta,
             t_max=simulator._tstop
         ).data,
     )
+
+    # test flip_y
+    simulator.add_movie(
+        'movie',
+        {'data': sample_movie.data,
+         'frame_rate': 1000.0,
+         'flip_y': True,
+         'y_dir': 'down'}
+    )
+
+    # flipped movie should have -theta direction.
+    # This won't be an exact match, because these two movies' starting point of the
+    # phase is different, but by adjusting theta to 9.59, we can make them have one
+    # cycle vertically, and they become close.
+    target_movie = GratingMovie(120, 80, y_dir='down').create_movie(
+        theta=-theta,
+        t_max=simulator._tstop
+    )
+    
+    assert np.allclose(
+        simulator._movies[1].data,
+        target_movie.data,
+        atol=1e-2
+    )
+    
 
 def build_simulator(tmp_path):
     data_dir = Path(__file__).parent / 'data' 

--- a/docs/autodocs/source/filternet.rst
+++ b/docs/autodocs/source/filternet.rst
@@ -41,7 +41,9 @@ Allows playing a custom movie file in the form of a three-dimension matrix saved
          "module": "movie",
          "data_file": "/path/to/my/movie.npy",
          "frame_rate": 1000.0,
-         "normalize": true
+         "normalize": true,
+         "y_dir": "down",
+         "flip_y": false
       }
    }
 
@@ -50,6 +52,8 @@ Allows playing a custom movie file in the form of a three-dimension matrix saved
 * normalize: Allow the option to normalize the input movie to have contrast values between [-1.0, +1.0].
   * If set to true then FilterNet will attempt to infer the current range of the original movie from the data (most movies use contrast between [0, 255] or [0.0, 1.0].
   * If the original movie has a unique range, users can specify the min/max contrast for the original movie ```"normalize": [0.0, 100.0]```
+* y_dir: Direction of the y-axis in the movie. Options are "up" or "down" (default: "down").
+* flip_y: Flip the y-axis of the movie (default: false).
 
 Grating
 +++++++
@@ -60,7 +64,7 @@ Plays a drifting grating across the screen
    {
       "gratings_input": {
          "input_type": "movie",
-         "module": "graiting",
+         "module": "grating",
          "row_size": 120,
          "col_size": 240,
          "gray_screen_dur": 0.5,
@@ -69,7 +73,8 @@ Plays a drifting grating across the screen
          "contrast": 0.8,
          "theta": 45.0,
          "phase": 0.0,
-         "degrees_per_pixel": 1.0
+         "degrees_per_pixel": 1.0,
+         "y_dir": "down"
       }
    }
 
@@ -81,6 +86,10 @@ Plays a drifting grating across the screen
 * phase: temporal phase, in degrees (default: 0.0)
 * contrast: the maximum constrast, must be between 0 and 1.0 (default: 1.0)
 * degrees_per_pixel: sampling pitch of the movie in degrees per pixel (default: 1 / (cpd * 10))
+* y_dir: Direction of the y-axis in the movie. Options are "up" or "down" (default: "down").
+
+Note: Theta is always defined as counterclockwise rotation from the x-axis
+regardless of how the Y-axis is defined.
 
 
 Full Field Flash
@@ -97,7 +106,8 @@ Creates a bright (or dark) flash on a gray screen for a limited number of second
          "col_size": 240,
          "t_on": 1000.0,
          "t_off": 2000.0,
-         "max_intensity": 20.0
+         "max_intensity": 20.0,
+         "y_dir": "down"
       }
    }
 
@@ -105,6 +115,7 @@ Creates a bright (or dark) flash on a gray screen for a limited number of second
 * t_on: time (ms) from the beginning on when to start the flash
 * t_off: length (ms) of flash
 * max_intensity: intensity of screen during flash (>0.0 is brighter, <0.0 is darker) compared to a gray screen.
+* y_dir: Direction of the y-axis in the movie. Options are "up" or "down" (default: "down").
 
 
 Looming
@@ -121,7 +132,8 @@ Creates a spreading black field originating from the center.
          "col_size": 240,
          "frame_rate": 1000.0,
          "gray_screen_dur": 0.5,
-         "t_looming": 1.0
+         "t_looming": 1.0,
+         "y_dir": "down"
       }
    }
 
@@ -129,6 +141,7 @@ Creates a spreading black field originating from the center.
 * frame_rate: frames per second
 * gray_screen_dur: duration of the initial grey screen (seconds)
 * t_looming: time of the looming movie (seconds).
+* y_dir: Direction of the y-axis in the movie. Options are "up" or "down" (default: "down").
 
 
 Optimizations Techniques

--- a/docs/tutorial/07_filter_models.ipynb
+++ b/docs/tutorial/07_filter_models.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Chapter 7: Modeling the visual field (with FilterNet)\n",
     "\n",
-    "FilterNet is a part of the BMTK that simulates the effects of visual input onto cells in the LGN. It uses LGNModel as a backend, which uses neural-filters to simulate firing rates and spike-trains one may expect given a stimulus on (especially mouse) visual field. FilterNet supports a number of visual stimuli including static-graitings, moving-graiting, full-field flashes, static images and even movies.\n",
+    "FilterNet is a part of the BMTK that simulates the effects of visual input onto cells in the LGN. It uses LGNModel as a backend, which uses neural-filters to simulate firing rates and spike-trains one may expect given a stimulus on (especially mouse) visual field. FilterNet supports a number of visual stimuli including static-gratings, moving-grating, full-field flashes, static images and even movies.\n",
     "\n",
     "Filternet uses a [__linear-nonlinear-Poisson (lnp) model__](https://en.wikipedia.org/wiki/Linear-nonlinear-Poisson_cascade_model), using a spatial-temporal linear filter to convert a movie into a series of spike trains.\n",
     "\n",
@@ -315,7 +315,7 @@
     "  \"inputs\": {\n",
     "    \"LGN_spikes\": {\n",
     "      \"input_type\": \"movie\",\n",
-    "      \"module\": \"graiting\",\n",
+    "      \"module\": \"grating\",\n",
     "      \"row_size\": 120,\n",
     "      \"col_size\": 240,\n",
     "      \"gray_screen_dur\": 0.5,\n",

--- a/examples/filter_graitings/config.simulation.json
+++ b/examples/filter_graitings/config.simulation.json
@@ -23,7 +23,7 @@
   "inputs": {
     "LGN_spikes": {
       "input_type": "movie",
-      "module": "graiting",
+      "module": "grating",
       "row_size": 120,
       "col_size": 240,
       "gray_screen_dur": 0.5,

--- a/examples/filter_graitings_preset/config.simulation.json
+++ b/examples/filter_graitings_preset/config.simulation.json
@@ -20,7 +20,7 @@
   "inputs": {
     "LGN_spikes": {
       "input_type": "movie",
-      "module": "graiting",
+      "module": "grating",
       "row_size": 120,
       "col_size": 240,
       "gray_screen_dur": 0.5,


### PR DESCRIPTION
I've added a new feature in BMTK to be compatible with the LGN of the new V1 model that has Y-axis defined upward. Currently, BMTK uses the downward Y-axis implicitly, while defining the angle of the drifting gratings using upward Y-axis. This may cause confusion, so I tried to make it more optional and explicit.

I did not change the default behavior, but implemented the 'y_dir' option, and the generation of the drifting gratings respect this option. Also, when movie is imported to BMTK, it can be optionally flipped along the Y-axis to resolve compatibility between the typical image format that uses the downward Y-axis and the new LGN model that uses the upward Y-axis.

A few tests were added for these changes and the documentation was updated.

Also, I've fixed a strange behavior of the 'add_movie' method for 'movie' option and 'data_file' is not specified. This method was supposed to work when 'data' was specified instead of 'data_file', but it wasn't.

On the minor thing, the spelling error for 'grating' was fixed on the examples in BMTK, and FilterNet is now compatible with both 'grating' and 'grating' for backward compatibility.