### PR TITLE
Fix Python3.12+ string syntax

### DIFF
--- a/bmtk/simulator/bionet/modules/comsol.py
+++ b/bmtk/simulator/bionet/modules/comsol.py
@@ -182,9 +182,9 @@ class ComsolMod(SimulatorMod):
         """
 
         # Extract column headers and data from comsol_file
-        headers = pd.read_csv(comsol_file, sep="\s{3,}", header=None, skiprows=8, nrows=1, engine='python')
+        headers = pd.read_csv(comsol_file, sep=r"\s{3,}", header=None, skiprows=8, nrows=1, engine='python')
         headers = headers.to_numpy()[0]
-        data = pd.read_csv(comsol_file, sep="\s+", header=None, skiprows=9)
+        data = pd.read_csv(comsol_file, sep=r"\s+", header=None, skiprows=9)
 
         # Convert V to mV if necessary
         if headers[3][3] == 'V':                        

--- a/bmtk/simulator/filternet/lgnmodel/util_fns.py
+++ b/bmtk/simulator/filternet/lgnmodel/util_fns.py
@@ -48,7 +48,7 @@ def create_ff_mov(frame_rate, tst, tend, xrng, yrng):
 ##################################################
 def create_grating_movie_list(gr_dir_name):
     gr_fnames = os.listdir(gr_dir_name)
-    gr_fnames_ord = sorted(gr_fnames, key=lambda x: (int(re.sub('\D', '', x)), x))
+    gr_fnames_ord = sorted(gr_fnames, key=lambda x: (int(re.sub(r'\D', '', x)), x))
 
     gr_mov_list = []
     for fname in gr_fnames_ord[:5]:

--- a/bmtk/utils/io/cell_vars.py
+++ b/bmtk/utils/io/cell_vars.py
@@ -16,7 +16,7 @@ class CellVarRecorder(object):
     _io = io
 
     class DataTable(object):
-        """A small struct to keep track of different \*/data (and buffer) tables"""
+        r"""A small struct to keep track of different \*/data (and buffer) tables"""
         def __init__(self, var_name):
             self.var_name = var_name
             # If buffering data, buffer_block will be an in-memory array and will write to data_block during when

--- a/bmtk/utils/sonata/config/sonata_config.py
+++ b/bmtk/utils/sonata/config/sonata_config.py
@@ -397,7 +397,7 @@ class ConfigParser(object):
         :return: json rvalue with resolved variables. Won't resolve variables that don't exist in manifest.
         """
         ret_val = json_str
-        variables = [m for m in re.finditer('\$\{?[\w]+\}?', json_str)]
+        variables = [m for m in re.finditer(r'\$\{?[\w]+\}?', json_str)]
         for var in variables:
             var_key = var.group()
             # change $VAR or ${VAR} --> VAR


### PR DESCRIPTION
Eliminates "SyntaxWarning: invalid escape sequence"

Originally reported at this Debian bug https://bugs.debian.org/1085366 and adapted from this patch in the Debian package of `bmtk`: https://salsa.debian.org/med-team/bmtk/-/blob/master/debian/patches/python3.12-syntax.patch?ref_type=heads
