### PR TITLE
Clarifying that tstart is non-functional in BMTK

### DIFF
--- a/docs/autodocs/source/simulators.rst
+++ b/docs/autodocs/source/simulators.rst
@@ -192,8 +192,7 @@ run
 +++
 contains simulation parameters. most importantly are
 
-* tstart: simulation start time in ms (default 0.0)
-* stop: final simulation time in ms
+* tstop: final simulation time in ms
 * dt: time step parameter
 * overwrite_output_dir: overwrites any previous ran results
 

--- a/docs/autodocs/source/simulators_guide.rst
+++ b/docs/autodocs/source/simulators_guide.rst
@@ -168,7 +168,7 @@ The following attributes can be used by BMTK to set to time course of a given si
         - Start time of simulation in ms (default 0.0; not currently used in BMTK)
         - False
       * - tstop
-        - Stop time of simulation (default 0.0)
+        - Stop time of simulation in ms
         - True
       * - dt
         - The time step of a simulation; ms

--- a/docs/autodocs/source/simulators_guide.rst
+++ b/docs/autodocs/source/simulators_guide.rst
@@ -165,7 +165,7 @@ The following attributes can be used by BMTK to set to time course of a given si
         - description
         - required
       * - tstart
-        - Start time of simulation in ms (default 0.0)
+        - Start time of simulation in ms (default 0.0; not currently used in BMTK)
         - False
       * - tstop
         - Stop time of simulation (default 0.0)


### PR DESCRIPTION
Subtle modification to the manual clarifying that 'tstart' parameter is not currently used in BMTK.