### PR TITLE
dpointnet: OOM + float16 fixes, inference input-current path, and trainable background + loss core

### DIFF
--- a/bmtk/simulator/dpointnet/__init__.py
+++ b/bmtk/simulator/dpointnet/__init__.py
@@ -2,3 +2,4 @@ from .rnn_model import RNN
 from .config import Config
 from .input_modules import InputModules
 from .loss_functions import register_loss_module, add_loss_module
+from .tf_utils import cleanup_tensorflow, enable_gpu_memory_growth

--- a/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
+++ b/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
@@ -284,6 +284,76 @@ def get_new_inds_table(indices, weights, syn_ids, non_zero_cols, pre_ind_table):
     return new_indices, new_weights, new_syn_ids, post_in_degree, all_synapse_inds
 
 
+@tf.custom_gradient
+def calculate_input_currents(x_t, input_indices, input_weight_values, input_weight_values_compute,
+                             input_dense_shape, synaptic_basis_weights, input_syn_ids, pre_input_ind_table):
+    """Memory-efficient input (LGN/background) synaptic current, mirroring
+    ``calculate_synaptic_currents`` but for an external spike input ``x_t``.
+
+    Forward: I[b,post,r] = sum_pre( x_t[b,pre] * W_in[post,pre] * basis[type,r] ), where
+    ``x_t[b,pre]`` may be a multi-spike count (not just 0/1). Forward reads the compute-dtype
+    shadow ``input_weight_values_compute``; the custom backward returns the gradient w.r.t. the
+    trainable master ``input_weight_values`` and recomputes the cheap basis gather instead of
+    retaining per-timestep activations. The plain-autodiff version stacked those activations
+    across the whole sequence, which dominated background-input memory at high firing rates.
+    No gradient flows to ``x_t`` (external input).
+    """
+    batch_size = tf.cast(tf.shape(x_t)[0], dtype=tf.int64)
+    # input_dense_shape may be a Python/int32 tuple; force int64 for segment-id arithmetic
+    n_post_neurons = tf.cast(input_dense_shape[0], dtype=tf.int64)
+    compute_dtype = synaptic_basis_weights.dtype
+
+    if x_t.dtype == tf.bool:
+        non_zero_indices = tf.where(x_t)
+    else:
+        non_zero_indices = tf.where(x_t > 0)
+    batch_indices = non_zero_indices[:, 0]
+    pre_neuron_indices = non_zero_indices[:, 1]
+
+    new_indices, new_weights, new_syn_ids, post_in_degree, all_synaptic_inds = get_new_inds_table(
+        input_indices, input_weight_values_compute, input_syn_ids, pre_neuron_indices, pre_input_ind_table
+    )
+
+    batch_indices_per_connection = tf.repeat(batch_indices, post_in_degree)
+    post_neuron_indices = new_indices[:, 0]
+    segment_ids = batch_indices_per_connection * n_post_neurons + post_neuron_indices
+    segment_ids = tf.cast(segment_ids, dtype=tf.int32)
+    num_segments = tf.cast(batch_size * n_post_neurons, dtype=tf.int32)
+
+    basis_factors = tf.gather(synaptic_basis_weights, new_syn_ids, axis=0)
+    new_syn_ids = tf.cast(new_syn_ids, dtype=tf.int32)  # int32 to reduce VRAM (reused in backward)
+    # Per-connection presynaptic spike count (supports multi-spike inputs).
+    n_pre_spikes = tf.cast(tf.gather_nd(x_t, non_zero_indices), compute_dtype)
+    n_pre_per_connection = tf.repeat(n_pre_spikes, post_in_degree)
+    new_weights = tf.cast(new_weights, compute_dtype)
+    new_weights_final = (new_weights * n_pre_per_connection)[:, tf.newaxis] * basis_factors
+    i_in_flat = tf.math.unsorted_segment_sum(new_weights_final, segment_ids, num_segments)
+
+    def grad(dy):
+        # dL/dW_in[syn] = sum_b,r( dy[b,post[syn],r] * n_pre_spikes[syn] * basis[type[syn],r] )
+        dnew_weights = tf.gather(dy, segment_ids)                                     # [n_active, n_basis]
+        basis_factors_grad = tf.gather(synaptic_basis_weights, new_syn_ids, axis=0)   # recomputed (saves VRAM)
+        de_dweight_connection = tf.einsum('cr,cr->c', dnew_weights, basis_factors_grad) * n_pre_per_connection
+        de_dweight_values = tf.math.unsorted_segment_sum(
+            data=de_dweight_connection,
+            segment_ids=all_synaptic_inds,
+            num_segments=tf.shape(input_weight_values)[0],
+        )
+        de_dweight_values = tf.cast(de_dweight_values, dtype=input_weight_values.dtype)
+        return [
+            None,               # x_t (external input)
+            None,               # input_indices (constant)
+            de_dweight_values,  # input_weight_values (master, matches trainable dtype)
+            None,               # input_weight_values_compute (non-trainable shadow)
+            None,               # input_dense_shape[0] (constant)
+            None,               # input_dense_shape[1] (constant)
+            None,               # synaptic_basis_weights (constant)
+            None,               # input_syn_ids (constant)
+            None,               # pre_input_ind_table (constant)
+        ]
+
+    return i_in_flat, grad
+
 
 @njit(cache=True)
 def _build_csr_order_numba(pre_ids, n_source_neurons):
@@ -580,6 +650,20 @@ class GLIF3Cell(tf.keras.layers.Layer):
                 trainable=input_trainable,
                 dtype=self.variable_dtype
             )
+            # Non-trainable compute-dtype shadow (mirrors the recurrent weights): the input-current
+            # @tf.custom_gradient reads this in the forward (avoids casting in fp16 and avoids reading
+            # a trainable MirroredVariable inside the RNN while_loop), while the gradient targets the
+            # master above. Kept in sync via refresh_recurrent_weight_shadow() after each step.
+            if self.variable_dtype != self.compute_dtype or input_trainable:
+                _input_weight_compute = tf.Variable(
+                    tf.cast(input_props['input_weight_values'], self.compute_dtype),
+                    name=f'{input_name}_input_weights_compute',
+                    trainable=False,
+                    dtype=self.compute_dtype,
+                )
+                input_props['input_weight_values_compute'] = self._no_dependency(_input_weight_compute)
+            else:
+                input_props['input_weight_values_compute'] = input_props['input_weight_values']
             input_props['input_syn_ids'] = tf.constant(input_syn_ids, dtype=tf.int64) # for efficiency this needs to be in int64
             # if not self._current_input:
             #     input_props['pre_input_ind_table'] = make_pre_ind_table(
@@ -679,13 +763,20 @@ class GLIF3Cell(tf.keras.layers.Layer):
         forward keeps using stale weights and recurrent-weight training has no effect.
         Matches the reference V1_GLIF_model.
         """
-        if self.recurrent_weight_values_compute is self.recurrent_weight_values:
-            return
-        if not self.recurrent_weight_values.trainable:
-            return
-        self.recurrent_weight_values_compute.assign(
-            tf.cast(self.recurrent_weight_values, self.compute_dtype)
-        )
+        if (self.recurrent_weight_values_compute is not self.recurrent_weight_values
+                and self.recurrent_weight_values.trainable):
+            self.recurrent_weight_values_compute.assign(
+                tf.cast(self.recurrent_weight_values, self.compute_dtype)
+            )
+
+        # Also sync any trainable input-weight shadows (e.g. trainable background weights),
+        # which the input-current custom gradient reads in its forward pass.
+        for input_net in self.inputs.values():
+            master = input_net.get('input_weight_values')
+            shadow = input_net.get('input_weight_values_compute')
+            if shadow is None or shadow is master or not master.trainable:
+                continue
+            shadow.assign(tf.cast(master, self.compute_dtype))
 
     def calculate_i_rec_with_custom_grad(self, rec_z_buf):
         return calculate_synaptic_currents(
@@ -724,60 +815,19 @@ class GLIF3Cell(tf.keras.layers.Layer):
         return i_in_flat
 
     def calculate_input_current_from_spikes(self, x_t, input_net):
-        batch_size = tf.cast(tf.shape(x_t)[0], dtype=tf.int64) # int64
-        n_post_neurons = input_net['input_dense_shape'][0]
-        # n_post_neurons = self.lgn_input_dense_shape[0]
-        
-        # Find the indices of non-zero inputs
-        if x_t.dtype == tf.bool:
-            non_zero_indices = tf.where(x_t)
-        else:
-            non_zero_indices = tf.where(x_t > 0)
-
-        batch_indices = non_zero_indices[:, 0]  # int64
-        pre_neuron_indices = non_zero_indices[:, 1] #int64
-
-        # Get the indices into self.recurrent_indices for each pre_neuron_index
-        # self.pre_ind_table is a RaggedTensor or a list of lists mapping pre_neuron_index to indices in recurrent_indices
-        new_indices, new_weights, new_syn_ids, post_in_degree, _ = get_new_inds_table(
+        # Memory-efficient input current via the @tf.custom_gradient module function: the forward
+        # reads the compute-dtype shadow and the backward recomputes the cheap basis gather (instead
+        # of retaining per-timestep activations), while the gradient targets the trainable master.
+        return calculate_input_currents(
+            x_t,
             input_net['input_indices'],
             input_net['input_weight_values'],
+            input_net['input_weight_values_compute'],
+            input_net['input_dense_shape'],
+            self.synaptic_basis_weights,
             input_net['input_syn_ids'],
-            pre_neuron_indices,
-            input_net['pre_input_ind_table']
-            
-            
-            # self.input_indices,
-            # self.input_weight_values,
-            # self.input_syn_ids,
-            # pre_neuron_indices,
-            # self.pre_input_ind_table
+            input_net['pre_input_ind_table'],
         )
-
-        # Expand batch_indices to match the length of inds_flat
-        batch_indices_per_connection = tf.repeat(batch_indices, post_in_degree) #int64
-        # Get post-synaptic neuron indices
-        post_neuron_indices = new_indices[:, 0] #int64
-        # Compute segment IDs
-        segment_ids = batch_indices_per_connection * n_post_neurons + post_neuron_indices
-        segment_ids = tf.cast(segment_ids, dtype=tf.int32)
-        num_segments = tf.cast(batch_size * n_post_neurons, dtype=tf.int32)
-        # Compute weighted basis factors
-        basis_factors = tf.gather(self.synaptic_basis_weights, new_syn_ids, axis=0)  # shape (n_active_connections, n_syn_basis)
-        # Accumulate currents in variable_dtype for better numerical fidelity, then cast once.
-        n_pre_spikes = tf.cast(tf.gather_nd(x_t, non_zero_indices), dtype=self.compute_dtype)
-        new_weights = tf.cast(new_weights, self.compute_dtype)
-        new_weights_final = (new_weights * tf.repeat(n_pre_spikes, post_in_degree))[:, tf.newaxis] * basis_factors
-        # new_weights_final = new_weights[:, tf.newaxis] * basis_factors
-
-        # Calculate input currents
-        i_in_flat = tf.math.unsorted_segment_sum(new_weights_final, segment_ids, num_segments)
-
-        # Cast back to compute_dtype to keep downstream state buffers compact.
-        # if i_in_flat.dtype != self.compute_dtype:
-        #     i_in_flat = tf.cast(i_in_flat, dtype=self.compute_dtype)
-
-        return i_in_flat
 
     def update_psc(self, psc, psc_rise, rec_inputs):
         new_psc_rise = psc_rise * self.syn_decay + rec_inputs * self.psc_initial

--- a/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
+++ b/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
@@ -452,7 +452,7 @@ class GLIF3Cell(tf.keras.layers.Layer):
         self.v_reset = tf.constant(0.0, dtype=self.compute_dtype)
 
         self.decay = tf.Variable(tf.gather(membrane_decay, self._node_type_ids), trainable=False, dtype=self.compute_dtype)
-        self.current_factor = tf.Variable(tf.gather(membrane_decay, self._node_type_ids), trainable=False, dtype=self.compute_dtype)
+        self.current_factor = tf.Variable(tf.gather(current_factor, self._node_type_ids), trainable=False, dtype=self.compute_dtype)
 
         ## TODO: This shouldn't be stored in a separate pickle.
         # path = os.path.join(glif_network["data_dir"], 'tf_data', 'syn_id_to_syn_weights_dict.pkl')
@@ -545,14 +545,16 @@ class GLIF3Cell(tf.keras.layers.Layer):
             input_weights = input_weights / voltage_scale[self._node_type_ids[input_indices[:, 0]]]
             input_props['input_indices'] = tf.Variable(input_indices, trainable=False, dtype=tf.int64)
 
+            input_type = input_network['input_type']
+            input_options = input_network.get('options', {})
             input_weight_positive = tf.constant(input_weights >= 0, dtype=tf.bool)
-            input_trainable = input_network['options'].get('trainable', False)
+            input_trainable = input_options.get('trainable', False)
 
             input_props['input_weight_values'] = tf.Variable(
-                input_weights * input_network['options'].get('weight_scale', 1.0) / lr_scale,
+                input_weights * input_options.get('weight_scale', 1.0) / lr_scale,
                 name=f'{input_name}_input_weights',
                 constraint=SignedConstraint(input_weight_positive),
-                trainable=input_trainable, # input_network['options'].get('trainable', False),
+                trainable=input_trainable,
                 dtype=self.variable_dtype
             )
             input_props['input_syn_ids'] = tf.constant(input_syn_ids, dtype=tf.int64) # for efficiency this needs to be in int64
@@ -561,23 +563,14 @@ class GLIF3Cell(tf.keras.layers.Layer):
             #         input_indices, 
             #         n_source_neurons=input_dense_shape[1]
             #     )
-            input_type = input_network['options'].get('input_type', 'spikes')
-            input_props['type'] = input_type
+            input_props['input_type'] = input_type
             if input_type == 'spikes':
                 input_props['pre_input_ind_table'] = make_pre_ind_table(
                     input_indices, 
                     n_source_neurons=input_dense_shape[1]
                 )
                 end_indx = self.inputs_idx[idx] + n_input_nodes
-            elif input_type == 'noisy_current':
-                firing_rate = input_network['options'].get('firing_rate', 250.0)
-                input_props['spike_prob'] = tf.constant(firing_rate * 0.001, dtype=self.compute_dtype)
-                input_props['pre_input_ind_table'] = make_pre_ind_table(
-                    input_indices, 
-                    n_source_neurons=input_dense_shape[1]
-                )
-                end_indx = self.inputs_idx[idx]
-            elif input_type == 'current_input':
+            elif input_type == 'current':
                 end_indx = self.inputs_idx[idx] + n_input_nodes
             else:
                 raise ValueError(f'Unknown input type {input_type}')
@@ -708,8 +701,9 @@ class GLIF3Cell(tf.keras.layers.Layer):
         # Compute weighted basis factors
         basis_factors = tf.gather(self.synaptic_basis_weights, new_syn_ids, axis=0)  # shape (n_active_connections, n_syn_basis)
         # Accumulate currents in variable_dtype for better numerical fidelity, then cast once.
+        n_pre_spikes = tf.cast(tf.gather_nd(x_t, non_zero_indices), dtype=self.compute_dtype)
         new_weights = tf.cast(new_weights, self.compute_dtype)
-        new_weights_final = new_weights[:, tf.newaxis] * basis_factors
+        new_weights_final = (new_weights * tf.repeat(n_pre_spikes, post_in_degree))[:, tf.newaxis] * basis_factors
         # new_weights_final = new_weights[:, tf.newaxis] * basis_factors
 
         # Calculate input currents
@@ -862,14 +856,11 @@ class GLIF3Cell(tf.keras.layers.Layer):
         
         extern_currents = []
         for idx, input_net in enumerate(self.inputs.values()):
-            if input_net['type'] == 'noisy_current':
-                extern_currents.append(self.calculate_noise_current(batch_size, noise_step, input_net))
+            input_spikes = inputs[:, self.inputs_idx[idx]:self.inputs_idx[idx+1]]
+            if input_net['input_type'] == 'current':
+                extern_currents.append(self.calculate_input_current_from_firing_probabilities(input_spikes))
             else:
-                input_spikes = inputs[:, self.inputs_idx[idx]:self.inputs_idx[idx+1]]
-                if input_net['type'] == 'current_input':
-                    extern_currents.append(self.calculate_input_current_from_firing_probabilities(input_spikes))
-                else:
-                    extern_currents.append(self.calculate_input_current_from_spikes(input_spikes, input_net))
+                extern_currents.append(self.calculate_input_current_from_spikes(input_spikes, input_net))
         
         rec_inputs = i_rec + tf.add_n(extern_currents)
 

--- a/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
+++ b/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
@@ -687,6 +687,30 @@ class GLIF3Cell(tf.keras.layers.Layer):
             self.pre_ind_table
         )
 
+    def calculate_input_current_from_firing_probabilities(self, x_t, input_net):
+        """Input current when the input is firing PROBABILITIES (rate/'current' input) rather
+        than discrete spikes. Computes I[:, post, r] = sum_pre w[post,pre]*basis[type,r]*prob[pre]
+        via a per-receptor sparse-dense matmul. Ported from the reference V1_GLIF_model;
+        uses the per-input dict (input_net) like calculate_input_current_from_spikes.
+        """
+        batch_size = tf.shape(x_t)[0]
+        input_indices = input_net['input_indices']
+        input_weight_values = input_net['input_weight_values']
+        input_syn_ids = input_net['input_syn_ids']
+        input_dense_shape = input_net['input_dense_shape']
+
+        i_in = tf.TensorArray(dtype=self.compute_dtype, size=self._n_syn_basis)
+        for r_id in range(self._n_syn_basis):
+            input_weights_factors = tf.gather(self.synaptic_basis_weights[:, r_id], input_syn_ids, axis=0)
+            weights_syn_receptors = tf.cast(input_weight_values, self.compute_dtype) * input_weights_factors
+            sparse_w_in = tf.sparse.SparseTensor(input_indices, weights_syn_receptors, input_dense_shape)
+            i_receptor = tf.sparse.sparse_dense_matmul(sparse_w_in, tf.cast(x_t, self.compute_dtype), adjoint_b=True)
+            i_in = i_in.write(r_id, i_receptor)
+        i_in = i_in.stack()
+        i_in = tf.transpose(i_in)  # -> [batch, n_neurons, n_syn_basis] after reshape
+        i_in_flat = tf.reshape(i_in, [batch_size * self._n_neurons, self._n_syn_basis])
+        return i_in_flat
+
     def calculate_input_current_from_spikes(self, x_t, input_net):
         batch_size = tf.cast(tf.shape(x_t)[0], dtype=tf.int64) # int64
         n_post_neurons = input_net['input_dense_shape'][0]
@@ -886,7 +910,7 @@ class GLIF3Cell(tf.keras.layers.Layer):
         for idx, input_net in enumerate(self.inputs.values()):
             input_spikes = inputs[:, self.inputs_idx[idx]:self.inputs_idx[idx+1]]
             if input_net['input_type'] == 'current':
-                extern_currents.append(self.calculate_input_current_from_firing_probabilities(input_spikes))
+                extern_currents.append(self.calculate_input_current_from_firing_probabilities(input_spikes, input_net))
             else:
                 extern_currents.append(self.calculate_input_current_from_spikes(input_spikes, input_net))
         

--- a/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
+++ b/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
@@ -451,8 +451,14 @@ class GLIF3Cell(tf.keras.layers.Layer):
         self.v_th = tf.constant(1.0, dtype=self.compute_dtype)
         self.v_reset = tf.constant(0.0, dtype=self.compute_dtype)
 
-        self.decay = tf.Variable(tf.gather(membrane_decay, self._node_type_ids), trainable=False, dtype=self.compute_dtype)
-        self.current_factor = tf.Variable(tf.gather(current_factor, self._node_type_ids), trainable=False, dtype=self.compute_dtype)
+        # Cast before constructing the Variable: tf.Variable does not auto-cast a
+        # float32 initial value to a float16 compute_dtype under mixed precision.
+        self.decay = tf.Variable(
+            tf.cast(tf.gather(membrane_decay, self._node_type_ids), self.compute_dtype),
+            trainable=False, dtype=self.compute_dtype)
+        self.current_factor = tf.Variable(
+            tf.cast(tf.gather(current_factor, self._node_type_ids), self.compute_dtype),
+            trainable=False, dtype=self.compute_dtype)
 
         ## TODO: This shouldn't be stored in a separate pickle.
         # path = os.path.join(glif_network["data_dir"], 'tf_data', 'syn_id_to_syn_weights_dict.pkl')
@@ -505,9 +511,14 @@ class GLIF3Cell(tf.keras.layers.Layer):
             dtype=self.variable_dtype
         ) # shape = (n_synapses,)
 
-        if self.variable_dtype != self.compute_dtype:
-            # Keep a non-trainable compute-lane shadow to avoid full-table casts
-            # in the recurrent custom gradient path at every timestep.
+        if self.variable_dtype != self.compute_dtype or individual_training:
+            # Keep a non-trainable compute-lane shadow. Two reasons:
+            #  (1) mixed precision: avoids casting the full weight table every timestep;
+            #  (2) the recurrent @tf.custom_gradient reads these weights inside the RNN
+            #      while_loop. If that read is the *trainable* variable (esp. a MirroredVariable
+            #      under MirroredStrategy), TF requires the grad to take a `variables` kwarg and
+            #      otherwise errors. Reading a non-trainable shadow avoids that. The shadow is
+            #      kept in sync via refresh_recurrent_weight_shadow() after each optimizer step.
             recurrent_weight_values_compute = tf.Variable(
                 tf.cast(self.recurrent_weight_values, self.compute_dtype),
                 name="sparse_recurrent_weights_compute",
@@ -646,6 +657,23 @@ class GLIF3Cell(tf.keras.layers.Layer):
         print(f"    > # BKG input synapses {len(bkg_input_indices)}")
         del bkg_input_indices, bkg_input_weights, bkg_input_syn_ids, bkg_input_weight_positive #, bkg_input_delays
         '''
+
+    def refresh_recurrent_weight_shadow(self):
+        """Sync the compute-dtype shadow of the recurrent weights with the trained master.
+
+        Under mixed precision the forward uses ``recurrent_weight_values_compute`` (a
+        non-trainable float16 copy) while the optimizer updates the float32 master
+        ``recurrent_weight_values``. This must be called after each optimizer step, else the
+        forward keeps using stale weights and recurrent-weight training has no effect.
+        Matches the reference V1_GLIF_model.
+        """
+        if self.recurrent_weight_values_compute is self.recurrent_weight_values:
+            return
+        if not self.recurrent_weight_values.trainable:
+            return
+        self.recurrent_weight_values_compute.assign(
+            tf.cast(self.recurrent_weight_values, self.compute_dtype)
+        )
 
     def calculate_i_rec_with_custom_grad(self, rec_z_buf):
         return calculate_synaptic_currents(

--- a/bmtk/simulator/dpointnet/data_iterator.py
+++ b/bmtk/simulator/dpointnet/data_iterator.py
@@ -14,6 +14,10 @@ class DataIterator:
         self._is_built = False
         self._ret_list = False
 
+    def close(self):
+        self.data_itrs = []
+        self._is_built = False
+
     def build(self):
         self._is_built = False
         if isinstance(self.input_mods, InputsGeneratorMod):

--- a/bmtk/simulator/dpointnet/input_modules/__init__.py
+++ b/bmtk/simulator/dpointnet/input_modules/__init__.py
@@ -4,6 +4,7 @@ import pandas as pd
 from .inputs_base import InputsGeneratorMod
 from .lgn_generator import LGNGenerator
 from .noisy_current import NoisyCurrent
+from .poisson_spikes import PoissonSpikes
 from .rand_spikes_generator import RandomSpikesGenerator
 from .spikes_files_generator import SpikesFilesGenerator
 from .spikes_function_generator import SpikesFunctionGenerator, spikes_function
@@ -60,6 +61,7 @@ class InputModules:
 
 # input_modules_lu = InputModules()
 InputModules().add_module(NoisyCurrent, overwrite=False)
+InputModules().add_module(PoissonSpikes, overwrite=False)
 InputModules().add_module(LGNGenerator, overwrite=False)
 InputModules().add_module(LGNGenerator, module_name='lgn_tf', overwrite=False)
 InputModules().add_module(RandomSpikesGenerator, overwrite=False)

--- a/bmtk/simulator/dpointnet/input_modules/lgn_generator.py
+++ b/bmtk/simulator/dpointnet/input_modules/lgn_generator.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 import pandas as pd
 import numpy as np
+from pathlib import Path
 
 from bmtk.simulator.dpointnet.lgn_tf.lgn import LGN
 from bmtk.simulator.dpointnet.io_tools import io
@@ -17,10 +18,18 @@ class LGNGenerator(InputsGeneratorMod):
         self.stimulus_opts = kwargs['stimulus_options']
         self.row_size = self.stimulus_opts['row_size']
         self.col_size = self.stimulus_opts['col_size']
+        self._cache_paths = self._resolve_cache_paths(kwargs)
+
+        if kwargs.get('cache_overwrite', False):
+            for cache_path in self._cache_paths.values():
+                if cache_path is not None:
+                    Path(cache_path).unlink(missing_ok=True)
+
         self.lgn = LGN(
             network=input_network,
             row_size=self.row_size,
             col_size=self.col_size,
+            **self._cache_paths,
         )
 
         self._generator = None
@@ -58,6 +67,43 @@ class LGNGenerator(InputsGeneratorMod):
     @staticmethod
     def input_type():
         return 'spikes'
+
+    def _resolve_cache_paths(self, kwargs):
+        if not kwargs.get('cache_enabled', True):
+            return {
+                'spon_frs_path': None,
+                'temp_krns_path': None,
+                'spatial_krns_path': None,
+            }
+
+        cache_prefix = kwargs.get('cache_file', None)
+        if cache_prefix:
+            cache_prefix = Path(cache_prefix)
+            cache_prefix.parent.mkdir(parents=True, exist_ok=True)
+            cache_prefix = cache_prefix.with_suffix('')
+        else:
+            cache_dir = kwargs.get('cache_dir', None)
+            if cache_dir:
+                cache_root = Path(cache_dir)
+            else:
+                network_cache_file = getattr(self.input_network, '_cache_file', None)
+                if network_cache_file:
+                    cache_root = Path(network_cache_file).parent / 'lgn_cache'
+                else:
+                    cache_root = Path.cwd() / 'lgn_cache'
+
+            cache_root.mkdir(parents=True, exist_ok=True)
+            cache_key = kwargs.get('cache_key', None)
+            if cache_key is None:
+                n_inputs = getattr(self.input_network, 'n_nodes', 'unknown')
+                cache_key = f'{self.population_name}_{n_inputs}_{self.row_size}x{self.col_size}'
+            cache_prefix = cache_root / cache_key
+
+        return {
+            'spon_frs_path': str(cache_prefix.parent / f'{cache_prefix.name}.spontaneous.pkl'),
+            'temp_krns_path': str(cache_prefix.parent / f'{cache_prefix.name}.temporal.pkl'),
+            'spatial_krns_path': str(cache_prefix.parent / f'{cache_prefix.name}.spatial.pkl'),
+        }
     
 
 def _stateless_seed_pair(seed, salt=0):

--- a/bmtk/simulator/dpointnet/input_modules/poisson_spikes.py
+++ b/bmtk/simulator/dpointnet/input_modules/poisson_spikes.py
@@ -23,10 +23,14 @@ class PoissonSpikes(InputsGeneratorMod):
         _seq_len = seq_len or self.rnn.adjusted_seq_len
         lam = self._firing_rate * dt / 1000.0
         rng = np.random.default_rng(self._seed)
+        # Yield in the requested dtype so it matches the dataset output_signature below:
+        # tf.data.from_generator requires the numpy dtype to match the TensorSpec dtype,
+        # otherwise mixed-float16 runs error.
+        np_dtype = tf.as_dtype(dtype).as_numpy_dtype
 
         def _generator():
             while True:
-                spikes = rng.poisson(lam=lam, size=(_seq_len, self._n_nodes)).astype(np.float32)
+                spikes = rng.poisson(lam=lam, size=(_seq_len, self._n_nodes)).astype(np_dtype)
                 yield spikes, {'firing_rate': self._firing_rate}
 
         return tf.data.Dataset.from_generator(

--- a/bmtk/simulator/dpointnet/input_modules/poisson_spikes.py
+++ b/bmtk/simulator/dpointnet/input_modules/poisson_spikes.py
@@ -1,0 +1,38 @@
+from .inputs_base import InputsGeneratorMod
+import numpy as np
+import tensorflow as tf
+
+
+class PoissonSpikes(InputsGeneratorMod):
+    def __init__(self, rnn, name, input_network, **kwargs):
+        super().__init__(rnn=rnn, name=name, input_network=input_network, **kwargs)
+        input_network.input_type = 'spikes'
+        self._firing_rate = kwargs.get('firing_rate', 250.0)
+        self._seed = kwargs.get('seed', None)
+        self._n_nodes = input_network.n_nodes
+
+    @staticmethod
+    def module():
+        return 'poisson_spikes'
+
+    @staticmethod
+    def input_type():
+        return 'spikes'
+
+    def create_generator(self, seq_len=None, dt=1.0, dtype=tf.float32, **kwargs):
+        _seq_len = seq_len or self.rnn.adjusted_seq_len
+        lam = self._firing_rate * dt / 1000.0
+        rng = np.random.default_rng(self._seed)
+
+        def _generator():
+            while True:
+                spikes = rng.poisson(lam=lam, size=(_seq_len, self._n_nodes)).astype(np.float32)
+                yield spikes, {'firing_rate': self._firing_rate}
+
+        return tf.data.Dataset.from_generator(
+            _generator,
+            output_signature=(
+                tf.TensorSpec(shape=(_seq_len, self._n_nodes), dtype=dtype),
+                {'firing_rate': tf.TensorSpec(shape=(), dtype=tf.float32)}
+            )
+        )

--- a/bmtk/simulator/dpointnet/loss_functions/loss_utils.py
+++ b/bmtk/simulator/dpointnet/loss_functions/loss_utils.py
@@ -176,9 +176,15 @@ def get_pop_names(network, core_radius = None, n_selected_neurons=None, data_dir
 def isolate_core_neurons(network, radius=None, n_selected_neurons=None, data_dir='GLIF_network'):
     path_to_h5 = os.path.join(data_dir, 'network/v1_nodes.h5')
     with h5py.File(path_to_h5, mode='r') as node_h5:
-        x = np.array(node_h5['nodes']['v1']['0']['x'][()])[network['tf_id_to_bmtk_id']]
-        z = np.array(node_h5['nodes']['v1']['0']['z'][()])[network['tf_id_to_bmtk_id']]
-        
+        x = np.array(node_h5['nodes']['v1']['0']['x'][()])
+        z = np.array(node_h5['nodes']['v1']['0']['z'][()])
+    # The reference V1_GLIF_model reorders neurons (tf vs bmtk id); dpointnet keeps the
+    # native SONATA order (no 'tf_id_to_bmtk_id'), in which case the file order is the
+    # model order and no reindexing is needed.
+    if isinstance(network, dict) and ('tf_id_to_bmtk_id' in network):
+        x = x[network['tf_id_to_bmtk_id']]
+        z = z[network['tf_id_to_bmtk_id']]
+
     r = np.sqrt(x ** 2 + z ** 2)
     if radius is not None:
         selected_mask = r < radius
@@ -187,6 +193,21 @@ def isolate_core_neurons(network, radius=None, n_selected_neurons=None, data_dir
         selected_mask = np.isin(np.arange(len(r)), selected_mask)
     
     return selected_mask
+
+
+def resolve_core_mask(network, core_mask=None, core_radius=None, data_dir='GLIF_network'):
+    """Resolve a boolean core mask for a loss function.
+
+    If an explicit ``core_mask`` is given it is used as-is. Otherwise, if a ``core_radius``
+    is given, the central-core mask is computed from neuron positions (sqrt(x^2+z^2)<radius),
+    matching the reference V1_GLIF_model's ``loss_core_radius``. Returns ``None`` if neither
+    is provided (loss applies to all neurons).
+    """
+    if core_mask is not None:
+        return core_mask
+    if core_radius is not None:
+        return isolate_core_neurons(network, radius=core_radius, data_dir=data_dir)
+    return None
 
 
 def pop_name_to_cell_type(pop_name, ignore_l5e_subtypes=False):

--- a/bmtk/simulator/dpointnet/loss_functions/spike_rate_distribution_target.py
+++ b/bmtk/simulator/dpointnet/loss_functions/spike_rate_distribution_target.py
@@ -28,11 +28,17 @@ class SpikeRateDistributionTarget:
         self._pre_delay = int(pre_delay)
         self._post_delay = int(post_delay)
         self._rates_dampening = rates_dampening
-        self._core_mask = core_mask
         self._data_dir = data_dir
         self._dtype = dtype
         self._seed = seed
         self._neuropixels_df = neuropixels_df
+
+        # Restrict the rate-matching loss to a central core (matches the reference
+        # V1_GLIF_model's loss_core_radius). With no core, the loss averages over all
+        # ~66k neurons, which dilutes the per-neuron (and per-weight) gradient ~4x.
+        self._core_mask = loss_utils.resolve_core_mask(
+            self._network, core_mask, kwargs.get('core_radius'), self._data_dir
+        )
 
         # Mapping of stimulus type to neuropixels feature
         # If deprecated arguments are used, map them to stimulus_type

--- a/bmtk/simulator/dpointnet/loss_functions/synchronization_loss.py
+++ b/bmtk/simulator/dpointnet/loss_functions/synchronization_loss.py
@@ -18,8 +18,11 @@ class SynchronizationLoss(tf.keras.layers.Layer):
         self._t_end = t_end
         self._t_start_seconds = int(t_start * 1000)
         self._t_end_seconds = int(t_end * 1000)
-        self._core_mask = core_mask
         self._data_dir = data_dir
+        # Resolve core mask from an explicit mask or a core_radius (matches reference loss_core_radius).
+        self._core_mask = loss_utils.resolve_core_mask(
+            self._network, core_mask, kwargs.get('core_radius'), data_dir
+        )
         self._neuropixels_data_dir = neuropixels_data_dir
         self._dtype = dtype
         self._n_samples = n_samples
@@ -27,7 +30,7 @@ class SynchronizationLoss(tf.keras.layers.Layer):
 
         pop_names = loss_utils.get_pop_names(self._network)
         if self._core_mask is not None:
-            pop_names = pop_names[core_mask]
+            pop_names = pop_names[self._core_mask]
         node_ei = np.array([pop_name[0] for pop_name in pop_names])
         node_id = np.arange(len(node_ei))
         

--- a/bmtk/simulator/dpointnet/loss_functions/voltage_regularization.py
+++ b/bmtk/simulator/dpointnet/loss_functions/voltage_regularization.py
@@ -1,5 +1,7 @@
 import tensorflow as tf
 
+from . import loss_utils
+
 
 class VoltageRegularization:
     def __init__(self, rnn, voltage_cost=1e-5, dtype=tf.float32, core_mask=None, **kwargs):
@@ -7,7 +9,11 @@ class VoltageRegularization:
         self._voltage_cost = voltage_cost
         # self._cell = cell
         self._dtype = dtype
-        self._core_mask = core_mask
+        # Resolve core mask from an explicit mask or a core_radius (matches reference loss_core_radius).
+        self._core_mask = loss_utils.resolve_core_mask(
+            rnn.recurrent_network, core_mask, kwargs.get('core_radius'),
+            kwargs.get('data_dir', 'GLIF_network')
+        )
 
     @staticmethod
     def module():

--- a/bmtk/simulator/dpointnet/network_adaptor.py
+++ b/bmtk/simulator/dpointnet/network_adaptor.py
@@ -43,6 +43,7 @@ class NetworkAdaptor:
         # "current", or "na" (for unknown). Each input network can support multiple training
         # and predictions inputs but only of the same type.  
         self._input_type = None
+        self._input_options = {}
         self._source_tf_ids = None
         self._target_tf_ids = None
         self._edge_type_ids = None
@@ -85,6 +86,10 @@ class NetworkAdaptor:
             return self.n_nodes
         else:
             return 0
+
+    @property
+    def input_options(self):
+        return self._input_options
 
     @property
     def source_tf_ids(self):
@@ -139,6 +144,10 @@ class NetworkAdaptor:
         rec_networks = []
         input_networks = []
         names = set()
+
+        # Reset shared syn_id mapping so all SONATA networks built here share
+        # a single consistent set of syn_ids / basis_weights indices.
+        SONATANetwork.reset_global_syn_id_mapping()
 
         if networks_dict.keys() == {'networks'}:
             networks_dict = networks_dict['networks']
@@ -366,6 +375,18 @@ class CachedNetwork(NetworkAdaptor):
            
 
 class SONATANetwork(NetworkAdaptor):
+    # Class-level shared mapping: dynamics_params_path -> global index.
+    # Ensures all network instances (recurrent + inputs) use consistent syn_ids
+    # that index into a single shared basis_weights table.
+    _global_dyn_params_idx_lu = {}
+    _global_ordered_dyn_param_dicts = []
+
+    @classmethod
+    def reset_global_syn_id_mapping(cls):
+        """Reset the shared syn_id mapping (call before building a new model)."""
+        cls._global_dyn_params_idx_lu = {}
+        cls._global_ordered_dyn_param_dicts = []
+
     def __init__(self, sonata_node_pop, network_type, cache_file=False, filter=None, **opt_args):
         super().__init__(name=sonata_node_pop.name, network_type=network_type)
         self._sonata_node_pop = sonata_node_pop
@@ -454,8 +475,10 @@ class SONATANetwork(NetworkAdaptor):
             self._basis_weights = {r['name']: np.array([r['w0'], r['w1'], r['w2'], r['w3']]) for _, r in basis_weights_df.iterrows()}
 
     def _synaptic_dyn_params(self, format='dict'):
-        dynamic_params_idx_lu = {}
-        ordered_dyn_param_dicts = []
+        # Use class-level shared mapping to ensure all networks (recurrent + inputs)
+        # assign consistent syn_ids that index into one global basis_weights table.
+        dynamic_params_idx_lu = SONATANetwork._global_dyn_params_idx_lu
+        ordered_dyn_param_dicts = SONATANetwork._global_ordered_dyn_param_dicts
 
         data_table = {}
         for edge_pop in self._sonata_edge_pops:
@@ -533,7 +556,7 @@ class SONATANetwork(NetworkAdaptor):
         self._target_tf_ids = np.zeros(n_edges, dtype=np.uint32)
         self._edge_type_ids = np.zeros(n_edges, dtype=np.uint32)
         weights = np.zeros(n_edges, dtype=np.float32)
-        delays = np.zeros(n_edges, dtype=np.uint32)
+        delays = np.zeros(n_edges, dtype=np.float32)
         syn_ids = np.zeros(n_edges, dtype=np.uint8)
         syn_dyn_params, syn_dyn_parms_lu = self._synaptic_dyn_params()
         
@@ -594,7 +617,7 @@ class SONATANetwork(NetworkAdaptor):
                 'asc_amps': np.array(self._dynamics_params_lu['asc_amps'], dtype=np.float32)
             },
             'synapses': {
-                'indices': np.column_stack((self._target_tf_ids, self._source_tf_ids)),
+                'indices': indices,
                 'weights': weights.astype(np.float32),
                 'delays': delays,
                 'dense_shape': (n_nodes, n_nodes),
@@ -625,8 +648,8 @@ class SONATANetwork(NetworkAdaptor):
         self._source_tf_ids = np.zeros((n_edges,), dtype=np.uint32)
         self._target_tf_ids = np.zeros(n_edges, dtype=np.uint32)
         self._edge_type_ids = np.zeros(n_edges, dtype=np.uint32)
-        weights = np.zeros(n_edges, dtype=np.uint32)
-        delays = np.zeros(n_edges, dtype=np.uint32)
+        weights = np.zeros(n_edges, dtype=np.float32)
+        delays = np.zeros(n_edges, dtype=np.float32)
         syn_ids = np.zeros(n_edges, dtype=np.uint8)
 
         idx_beg, idx_end = 0, 0
@@ -670,13 +693,14 @@ class SONATANetwork(NetworkAdaptor):
         net_dict = {
             'name': self.name,
             'network_type': self.network_type,
+            'input_type': self.input_type,
             'node_params': node_params,
             'n_inputs': len(self._sonata_node_pop.node_ids),
             'indices': np.column_stack((self._target_tf_ids, self._source_tf_ids)),
             'weights': weights,
             'delays': delays,
             'syn_ids': syn_ids,
-            'options': {}
+            'options': dict(self.input_options)
         }
 
         if self._cache_file and not Path(self._cache_file).exists():

--- a/bmtk/simulator/dpointnet/rnn_model.py
+++ b/bmtk/simulator/dpointnet/rnn_model.py
@@ -626,6 +626,16 @@ class RNN:
                 input_population = mod_params['node_set']
                 input_network = self.get_input_network(input_population)
 
+                # Honor config-level input weight options (e.g. trainable, weight_scale) so the
+                # cell's input weights follow the config. These end up in the network's options
+                # dict, which is what to_dict() exposes and the GLIF cell reads when creating the
+                # input weight Variable. Without this the config's per-input "trainable" was a
+                # no-op and inputs (incl. the background) could never be trained (cf. the
+                # reference V1_GLIF_model which trains the bkg "rest_of_brain" weights).
+                for _opt in ('trainable', 'weight_scale'):
+                    if _opt in mod_params:
+                        input_network.options[_opt] = mod_params[_opt]
+
                 io.log_info(f'Building "{mod_name}" inputs for {input_population}')
                 module_cls = inputs_modules_lu.get_module(
                     input_type=mod_params['input'],

--- a/bmtk/simulator/dpointnet/rnn_model.py
+++ b/bmtk/simulator/dpointnet/rnn_model.py
@@ -51,6 +51,11 @@ class Inference:
         else:
             return self.init_mod.get_state()
 
+    def close(self):
+        if self._data_itr is not None:
+            self._data_itr.close()
+            self._data_itr = None
+
 class RNN:
     """The primary model and simulation class for dpointnet.
 
@@ -110,6 +115,7 @@ class RNN:
         self.batch_size = batch_size
         self._adjusted_batch_size = None
 
+        tf_utils.enable_gpu_memory_growth()
         self.strategy = tf.distribute.OneDeviceStrategy(device='/gpu:0')
 
     @property
@@ -313,6 +319,18 @@ class RNN:
         _batch_size = batch_size or self.adjusted_batch_size
         _seq_len = seq_len or self.adjusted_seq_len
 
+        # Pre-populate the global syn_id mapping by scanning all networks (recurrent + inputs)
+        # BEFORE building any dict. This ensures the recurrent network's basis_weights table
+        # includes entries for input network dynamics_params as well.
+        from bmtk.simulator.dpointnet.network_adaptor import SONATANetwork
+        SONATANetwork.reset_global_syn_id_mapping()
+        all_networks = list(self._recurrent_networks.values()) + list(self._input_networks.values())
+        for net in all_networks:
+            if hasattr(net, '_synaptic_dyn_params'):
+                net._synaptic_dyn_params()
+
+        # Force rebuild of recurrent network dict (don't use cached version)
+        self._built_recurrent_net = None
         network = self.recurrent_network
         n_spiking_inputs = sum(i.n_spiking_nodes for i in self._input_networks.values())
         n_neurons = network['n_nodes']
@@ -447,6 +465,10 @@ class RNN:
             extractor_results=out
         )
         return extractor_results
+
+    def cleanup(self):
+        for inference in self._inferences:
+            inference.close()
 
     def train(self, training_engine=None):
         if self.extractor_model is None:

--- a/bmtk/simulator/dpointnet/rnn_model.py
+++ b/bmtk/simulator/dpointnet/rnn_model.py
@@ -116,7 +116,13 @@ class RNN:
         self._adjusted_batch_size = None
 
         tf_utils.enable_gpu_memory_growth()
-        self.strategy = tf.distribute.OneDeviceStrategy(device='/gpu:0')
+        tf_utils.enable_tensorflow_optimizations()
+        # MirroredStrategy (matches the reference V1_GLIF_model). With variables created in
+        # strategy.scope() (see build()), the connectivity-variable reads are hoisted out of
+        # the RNN while_loop as loop-invariant captures instead of being stacked per timestep;
+        # OneDeviceStrategy does NOT do this and OOMs on the full network. Single visible GPU
+        # => effectively one device.
+        self.strategy = tf.distribute.MirroredStrategy()
 
     @property
     def input_modules(self):
@@ -352,41 +358,50 @@ class RNN:
             state_input_holder = None
             full_inputs = extrn_inputs
 
+        # Build the model (cell + RNN + variables) INSIDE the distribution strategy scope.
+        # Required for MirroredStrategy (variables must be created in scope), and it is also
+        # what makes the loop-invariant connectivity-variable reads be hoisted out of the RNN
+        # while_loop instead of stacked per timestep (the cause of full-network OOM). Mirrors
+        # the reference V1_GLIF_model, which builds create_model() within strategy.scope().
         cell_params = {} if self.cell_params is None else self.cell_params
-        self._cell = self.cell_cls(network, inputs=inputs_dicts, train_recurrent_per_type=False, **cell_params)
-        self.zero_state, state_names = self._cell.zero_state(self.batch_size, self.dtype, with_names=True)
+        with self.strategy.scope():
+            self._cell = self.cell_cls(network, inputs=inputs_dicts, train_recurrent_per_type=False, **cell_params)
+            self.zero_state, state_names = self._cell.zero_state(self.batch_size, self.dtype, with_names=True)
 
-        if use_state_input:
-            initial_state_holder = tuple(
-                tf.keras.layers.Input(shape=s.shape[1:], dtype=s.dtype, name=n)
-                for s, n in zip(self.zero_state, state_names)
-            )
-            rnn_initial_state = tf.nest.map_structure(tf.identity, initial_state_holder)
-        else:
-            initial_state_holder = None
-            rnn_initial_state = self.zero_state
-            
-        rnn = tf.keras.layers.RNN(self._cell, return_sequences=True, return_state=return_state, name='rsnn')
-        rnn_layer = rnn(full_inputs, initial_state=rnn_initial_state)
-
-        rnn_out = rnn_layer[0] if return_state else rnn_layer
-        spikes_output = rnn_out[0]
-
-        output = tf.keras.layers.Dense(n_output, name='projection', trainable=False)(spikes_output)
-
-        if use_state_input:
-            if use_dummy_state_input:
-                inputs = [extrn_inputs, state_input_holder, initial_state_holder]
+            if use_state_input:
+                initial_state_holder = tuple(
+                    tf.keras.layers.Input(shape=s.shape[1:], dtype=s.dtype, name=n)
+                    for s, n in zip(self.zero_state, state_names)
+                )
+                rnn_initial_state = tf.nest.map_structure(tf.identity, initial_state_holder)
             else:
-                inputs = [extrn_inputs, initial_state_holder]
-        else:
-            if use_dummy_state_input:
-                inputs = [extrn_inputs, state_input_holder]
-            else:
-                inputs = [extrn_inputs]
+                initial_state_holder = None
+                rnn_initial_state = self.zero_state
 
-        self.model = tf.keras.Model(inputs=inputs, outputs=[output])
-        self.model.build((_batch_size, _seq_len, n_spiking_inputs))
+            rnn = tf.keras.layers.RNN(self._cell, return_sequences=True, return_state=return_state, name='rsnn')
+            # Keep the cell's provided state dtypes instead of letting Keras autocast them to the
+            # compute dtype. Matches the reference (V1_GLIF_model create_model).
+            rnn._autocast = False
+            rnn_layer = rnn(full_inputs, initial_state=rnn_initial_state)
+
+            rnn_out = rnn_layer[0] if return_state else rnn_layer
+            spikes_output = rnn_out[0]
+
+            output = tf.keras.layers.Dense(n_output, name='projection', trainable=False)(spikes_output)
+
+            if use_state_input:
+                if use_dummy_state_input:
+                    inputs = [extrn_inputs, state_input_holder, initial_state_holder]
+                else:
+                    inputs = [extrn_inputs, initial_state_holder]
+            else:
+                if use_dummy_state_input:
+                    inputs = [extrn_inputs, state_input_holder]
+                else:
+                    inputs = [extrn_inputs]
+
+            self.model = tf.keras.Model(inputs=inputs, outputs=[output])
+            self.model.build((_batch_size, _seq_len, n_spiking_inputs))
         self._model_built = True
 
     @property
@@ -471,26 +486,29 @@ class RNN:
             inference.close()
 
     def train(self, training_engine=None):
-        if self.extractor_model is None:
-            self.extractor_model = tf.keras.Model(
-                inputs=self.model.inputs, 
-                outputs=self.model.get_layer('rsnn').output
-            )
+        with self.strategy.scope():
+            if self.extractor_model is None:
+                self.extractor_model = tf.keras.Model(
+                    inputs=self.model.inputs,
+                    outputs=self.model.get_layer('rsnn').output
+                )
 
         training_engine = training_engine or self.training_engine
         if training_engine is None:
             io.log_debug('No training condition has been set, skipping training.')
 
-        ## Build the optimizer 
-        optimizer = training_engine.optimizer
-        optimizer.build(self.model.trainable_variables)
+        ## Build the optimizer (in strategy scope so its slot variables are created correctly)
+        with self.strategy.scope():
+            optimizer = training_engine.optimizer
+            optimizer.build(self.model.trainable_variables)
 
         if self.dtype == 'float16':
-            # Prevent gradient underflow in mixed-float16 training.
-            if self.mixed_precision_module is None:
-                from tensorflow.keras import mixed_precision as mixed_precision_module
-
+            # Prevent gradient underflow in mixed-float16 training. The wrapped optimizer
+            # must be set back on the engine so the train step scales the loss / unscales
+            # the gradients (scale_loss_for_optimizer only acts on a LossScaleOptimizer).
+            from tensorflow.keras import mixed_precision as mixed_precision_module
             optimizer = mixed_precision_module.LossScaleOptimizer(optimizer)
+            training_engine.set_optimizer(optimizer)
 
         training_engine.train()
 
@@ -739,11 +757,13 @@ class RNN:
             n_epochs = train_dict['n_epochs']
             steps_per_epoch = train_dict['steps_per_epoch']
             training_approach = train_dict.get('training_approach', None)
+            gradient_checkpointing = train_dict.get('gradient_checkpointing', False)
             training_engine = network.set_training(
                 rnn=network,
-                n_epochs=n_epochs, 
+                n_epochs=n_epochs,
                 steps_per_epoch=steps_per_epoch,
-                training_approach=training_approach
+                training_approach=training_approach,
+                gradient_checkpointing=gradient_checkpointing
             )
 
             learning_rate = train_dict['learning_rate']

--- a/bmtk/simulator/dpointnet/tf_utils.py
+++ b/bmtk/simulator/dpointnet/tf_utils.py
@@ -18,6 +18,38 @@ def enable_gpu_memory_growth():
             )
 
 
+def enable_tensorflow_optimizations(enabled=True):
+    """Enable Grappler graph optimizations (matches the reference V1_GLIF_model).
+
+    The critical one for this model is ``loop_optimization``: it performs loop-invariant
+    code motion, hoisting the constant connectivity-variable reads (recurrent/LGN
+    indices, weights, syn_ids) OUT of the RNN tf.while_loop body. Without it, TF re-reads
+    those large tables every timestep and stacks them for the backward pass, which makes
+    backward memory scale with seq_len and OOMs full-network training. ``min_graph_nodes=0``
+    lets Grappler optimize the many small subgraphs in this model.
+    """
+    if not enabled:
+        return
+    try:
+        tf.config.optimizer.set_experimental_options({
+            "layout_optimizer": True,
+            "constant_folding": True,
+            "shape_optimization": True,
+            "remapping": True,
+            "arithmetic_optimization": True,
+            "dependency_optimization": True,
+            "loop_optimization": True,
+            "function_optimization": True,
+            "scoped_allocator_optimization": True,
+            "pin_to_host_optimization": False,
+            "implementation_selector": True,
+            "auto_parallel": True,
+            "min_graph_nodes": 0,
+        })
+    except Exception as exc:  # pragma: no cover - defensive
+        io.log_warning(f'Could not set TensorFlow optimizer options: {exc}')
+
+
 def cleanup_tensorflow():
     tf.keras.backend.clear_session()
     gc.collect()

--- a/bmtk/simulator/dpointnet/tf_utils.py
+++ b/bmtk/simulator/dpointnet/tf_utils.py
@@ -1,7 +1,33 @@
+import gc
+
 import tensorflow as tf
 from packaging import version
 
 from .io_tools import io
+
+
+# Necessary not to occupy all the memory on a GPU.
+def enable_gpu_memory_growth():
+    gpus = tf.config.list_physical_devices('GPU')
+    for gpu in gpus:
+        try:
+            tf.config.experimental.set_memory_growth(gpu, True)
+        except RuntimeError as exc:
+            io.log_warning(
+                f'Could not set TensorFlow memory growth for {gpu.name}: {exc}'
+            )
+
+
+def cleanup_tensorflow():
+    tf.keras.backend.clear_session()
+    gc.collect()
+
+
+def _get_active_policy(mixed_precision, fallback_policy=None):
+    if hasattr(mixed_precision, 'global_policy'):
+        return mixed_precision.global_policy()
+
+    return fallback_policy
 
 
 def get_precision_policy_and_dtype(_dtype):
@@ -35,10 +61,29 @@ def get_precision_policy_and_dtype(_dtype):
 
     if version.parse(tf.__version__) < version.parse('2.4.0'):
         from tensorflow.keras.mixed_precision import experimental as mixed_precision
+
         policy = mixed_precision.Policy(policy_name)
         mixed_precision.set_policy(policy)
+        active_policy = _get_active_policy(mixed_precision, fallback_policy=policy)
     else:
         from tensorflow.keras import mixed_precision
+
         mixed_precision.set_global_policy(policy_name)
+        active_policy = _get_active_policy(mixed_precision)
+
+    active_policy_name = getattr(active_policy, 'name', None)
+    if active_policy_name != policy_name:
+        raise RuntimeError(
+            f'Failed to activate TensorFlow precision policy "{policy_name}". '
+            f'Current policy is "{active_policy_name}".'
+        )
+
+    io.log_info(
+        'TensorFlow precision policy set to '
+        f'"{active_policy_name}" '
+        f'(compute_dtype={active_policy.compute_dtype}, '
+        f'variable_dtype={active_policy.variable_dtype}, '
+        f'requested_dtype={dtype_name}).'
+    )
 
     return mixed_precision, resolved_dtype

--- a/bmtk/simulator/dpointnet/training.py
+++ b/bmtk/simulator/dpointnet/training.py
@@ -363,14 +363,17 @@ class TrainingEngine:
                 _pstate = _model_state[pidx_beg:pidx_end]
                 for loss_name, loss_fnc in p.loss_functions.items():
                     _loss = loss_fnc(
-                        spikes=_pspikes, 
-                        voltages=_pvolts, 
+                        spikes=_pspikes,
+                        voltages=_pvolts,
                         model_state=_pstate,
                         y=ysig
                     )
                     _total_loss += tf.cast(_loss, tf.float32)
                     loss_vals[p.name][loss_name] = _loss
-            
+                # Advance to this parameter's slice of the concatenated batch so the next
+                # parameter's losses are computed on its own spikes/voltages (not [0:end]).
+                pidx_beg = pidx_end
+
             _total_loss = tf.cast(_total_loss, tf.float32)
             total_loss = tf.nn.scale_regularization_loss(_total_loss)
             all_losses.append(total_loss)

--- a/bmtk/simulator/dpointnet/training.py
+++ b/bmtk/simulator/dpointnet/training.py
@@ -113,6 +113,17 @@ class TrainingEngine:
         self._training_approach = training_approach
         self._training_fnc = None
 
+        # Gradient checkpointing (a.k.a. recompute_grad): recompute the per-timestep
+        # RNN activations during the backward pass instead of storing all of them across
+        # the unrolled sequence. This is required to fit full-network BPTT (seq_len ~500)
+        # on a single GPU; mirrors the reference V1_GLIF_model implementation.
+        # NOTE: default off for now. The recompute_grad wrapping does not yet reach the
+        # reference's memory profile (the per-timestep constant retention persists and, in
+        # at least one case, checkpointing increased peak memory). Re-enable by default once
+        # checkpointing is fixed to match V1_GLIF_model.
+        self.gradient_checkpointing = kwargs.get('gradient_checkpointing', False)
+        self._extractor_forward = None
+
         self._batch_indices = None
 
         self._inputs_sig_factory = None
@@ -272,6 +283,19 @@ class TrainingEngine:
 
         return self._inputs_sig_factory
 
+    def _run_extractor(self, x, init_state):
+        """Run the extractor (RNN) forward pass, optionally with gradient checkpointing.
+
+        When ``gradient_checkpointing`` is enabled, the forward is wrapped in
+        ``tf.recompute_grad`` so the per-timestep activations are recomputed during the
+        backward pass rather than retained for the whole sequence. The forward path is
+        deterministic (background spikes are supplied as explicit inputs), so the recompute
+        reproduces the original forward exactly.
+        """
+        if self.gradient_checkpointing and self._extractor_forward is not None:
+            return self._extractor_forward(x, init_state)
+        return self.rnn.extractor_model((x, init_state))
+
     def _train_step_single(self, x, y, init_state):
         """Main training step when there is only one parameter (eg. one set of inputs/loss functions). 
             1. Feedforward input is applied to spike inputs "x" with model state "init_state"
@@ -285,7 +309,7 @@ class TrainingEngine:
         loss_vals = {pname: {}}
         input_spikes = x[0]
         with tf.GradientTape() as tape:
-            _out = self.rnn.extractor_model((input_spikes, init_state))
+            _out = self._run_extractor(input_spikes, init_state)
             _spikes_out, _v_out = _out[0]
             _model_state = _out[1:]
 
@@ -297,7 +321,7 @@ class TrainingEngine:
                     model_state=_model_state,
                     y=y
                 )
-                _total_loss += _loss
+                _total_loss += tf.cast(_loss, tf.float32)
                 loss_vals[pname][loss_name] = _loss
 
             _total_loss = tf.cast(_total_loss, tf.float32)
@@ -326,7 +350,7 @@ class TrainingEngine:
         x_concat = tf.concat(xs, axis=0)
         sigs = self.inputs_signature_factory.build(ys)
         with tf.GradientTape() as tape:
-            _out = self.rnn.extractor_model((x_concat, init_state))
+            _out = self._run_extractor(x_concat, init_state)
             _spikes_out, _v_out = _out[0]
             _model_state = _out[1:]
 
@@ -344,7 +368,7 @@ class TrainingEngine:
                         model_state=_pstate,
                         y=ysig
                     )
-                    _total_loss += _loss
+                    _total_loss += tf.cast(_loss, tf.float32)
                     loss_vals[p.name][loss_name] = _loss
             
             _total_loss = tf.cast(_total_loss, tf.float32)
@@ -369,7 +393,7 @@ class TrainingEngine:
         for p, x, y in zip(self.parameters, xs, ys):
             loss_vals[p.name] = {}
             with tf.GradientTape() as tape:
-                _out = self.rnn.extractor_model((x, init_state))
+                _out = self._run_extractor(x, init_state)
                 _spikes_out, _v_out = _out[0]
                 _model_state = _out[1:]
 
@@ -382,7 +406,7 @@ class TrainingEngine:
                         y=y
                     )
                     loss_vals[p.name][loss_name] = _loss
-                    _total_loss += _loss
+                    _total_loss += tf.cast(_loss, tf.float32)
 
                 _total_loss = tf.cast(_total_loss, tf.float32)
                 total_loss = tf.nn.scale_regularization_loss(_total_loss)
@@ -422,7 +446,7 @@ class TrainingEngine:
                         y=y
                     )
                     loss_vals[p.name][loss_name] = _loss
-                    _total_loss += _loss
+                    _total_loss += tf.cast(_loss, tf.float32)
 
                 _total_loss = tf.cast(_total_loss, tf.float32)
                 total_loss = tf.nn.scale_regularization_loss(_total_loss)
@@ -453,7 +477,7 @@ class TrainingEngine:
                         y=ysig
                     )
                     loss_vals[p.name][loss_name] = _loss
-                    _total_loss += _loss
+                    _total_loss += tf.cast(_loss, tf.float32)
             
             _total_loss = tf.cast(_total_loss, tf.float32)
             total_loss = tf.nn.scale_regularization_loss(_total_loss)
@@ -502,6 +526,16 @@ class TrainingEngine:
         # input_itrs = [DataIterator(p.input_generators, p.batch_size, p.seq_len, self.rnn.ordered_inputs_populations) for p in self.parameters]
         init_state = self.init_state.get_state()
 
+        # Build the gradient-checkpointed forward ONCE, eagerly, before the @tf.function
+        # train step is traced. tf.recompute_grad must wrap the function in eager context;
+        # applying it lazily during graph tracing does not establish the checkpoint
+        # boundary and the per-timestep activations are retained anyway.
+        if self.gradient_checkpointing and self._extractor_forward is None:
+            @tf.recompute_grad
+            def extractor_forward(x, fwd_init_state):
+                return self.rnn.extractor_model((x, fwd_init_state))
+            self._extractor_forward = extractor_forward
+
         try:
             self.callbacks.on_train_begin()
             for epoch in range(self.n_epochs):
@@ -511,6 +545,11 @@ class TrainingEngine:
                     self.callbacks.on_step_start()
                     spikes, ys = input_itr.next_spikes()
                     step_loss_vals = self._distributed_train_step(spikes, ys, init_state=init_state)
+                    # Propagate the just-updated master recurrent weights into the compute-dtype
+                    # shadow used by the forward pass (no-op when not using a shadow).
+                    cell = getattr(self.rnn, '_cell', None)
+                    if cell is not None and hasattr(cell, 'refresh_recurrent_weight_shadow'):
+                        cell.refresh_recurrent_weight_shadow()
                     self.callbacks.on_step_end(step_loss_vals)
 
                 validation_loss = self._distributed_validation_step(spikes, ys, init_state=init_state, training_approach=self.training_approach)

--- a/bmtk/simulator/dpointnet/training.py
+++ b/bmtk/simulator/dpointnet/training.py
@@ -474,14 +474,17 @@ class TrainingEngine:
                 _pstate = _model_state[pidx_beg:pidx_end]
                 for loss_name, loss_fnc in p.loss_functions.items():
                     _loss = loss_fnc(
-                        spikes=_pspikes, 
-                        voltages=_pvolts, 
+                        spikes=_pspikes,
+                        voltages=_pvolts,
                         model_state=_pstate,
                         y=ysig
                     )
                     loss_vals[p.name][loss_name] = _loss
                     _total_loss += tf.cast(_loss, tf.float32)
-            
+                # Advance to this parameter's slice so the next parameter's validation losses
+                # are computed on its own batch segment (mirrors the fix in _train_step_batched).
+                pidx_beg = pidx_end
+
             _total_loss = tf.cast(_total_loss, tf.float32)
             total_loss = tf.nn.scale_regularization_loss(_total_loss)
             loss_vals['__total_loss'] = total_loss

--- a/bmtk/simulator/dpointnet/training.py
+++ b/bmtk/simulator/dpointnet/training.py
@@ -502,22 +502,25 @@ class TrainingEngine:
         # input_itrs = [DataIterator(p.input_generators, p.batch_size, p.seq_len, self.rnn.ordered_inputs_populations) for p in self.parameters]
         init_state = self.init_state.get_state()
 
-        self.callbacks.on_train_begin()
-        for epoch in range(self.n_epochs):
-            self.callbacks.on_epoch_start()
-            
-            for step in range(self.steps_per_epoch):
-                self.callbacks.on_step_start()
-                spikes, ys = input_itr.next_spikes()
-                step_loss_vals = self._distributed_train_step(spikes, ys, init_state=init_state)
-                self.callbacks.on_step_end(step_loss_vals)
+        try:
+            self.callbacks.on_train_begin()
+            for epoch in range(self.n_epochs):
+                self.callbacks.on_epoch_start()
+                
+                for step in range(self.steps_per_epoch):
+                    self.callbacks.on_step_start()
+                    spikes, ys = input_itr.next_spikes()
+                    step_loss_vals = self._distributed_train_step(spikes, ys, init_state=init_state)
+                    self.callbacks.on_step_end(step_loss_vals)
 
-            validation_loss = self._distributed_validation_step(spikes, ys, init_state=init_state, training_approach=self.training_approach)
-            stop = self.callbacks.on_epoch_end(validation_loss)
-            if stop:
-                break
+                validation_loss = self._distributed_validation_step(spikes, ys, init_state=init_state, training_approach=self.training_approach)
+                stop = self.callbacks.on_epoch_end(validation_loss)
+                if stop:
+                    break
 
-        self.callbacks.on_train_end()
+            self.callbacks.on_train_end()
+        finally:
+            input_itr.close()
     
 
     '''

--- a/examples/dpointnet_v1/configs/config.full.multispikes.inseries.json
+++ b/examples/dpointnet_v1/configs/config.full.multispikes.inseries.json
@@ -14,7 +14,7 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device",
     "checkpoint": {}
   },
@@ -99,7 +99,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_stateX": {
       "module": "zero_state"
@@ -132,7 +132,7 @@
         "loss_functions": {
           "evoked_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -141,13 +141,13 @@
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
-            "voltage_cost": 1.5,
+            "voltage_cost": 1.0,
             "penalty_mode": "range"
           },
           "evoked_sync_loss": {
             "enabled": true,
             "module": "SynchronizationLoss",
-            "sync_cost": 1.0,
+            "sync_cost": 1.5,
             "t_start": 0.2,
             "t_end": 0.5,
             "n_samples": 500,
@@ -166,7 +166,7 @@
         "loss_functions": {
           "spont_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,

--- a/examples/dpointnet_v1/configs/config.full.multispikes.inseries.json
+++ b/examples/dpointnet_v1/configs/config.full.multispikes.inseries.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -18,11 +16,8 @@
     "train_recurrent_weights": true,
     "dtype": "float32",
     "single_gpu_strategy": "one_device",
-    "checkpoint": {
-        
-    }    
+    "checkpoint": {}
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -34,9 +29,13 @@
     "lr_scale": 1.0,
     "max_delay": 5,
     "hard_reset": false,
-    "tau_syns": [0.7579732, 1.60809441, 3.41168742, 7.23813909]
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
-
   "inputs": {
     "lgn_evoked": {
       "node_set": "lgn",
@@ -44,47 +43,48 @@
       "module": "lgn_tf",
       "stimulus_type": "drifting_gratings",
       "stimulus_options": {
-          "orientation": null,
-          "temporal_f": 2.0,
-          "row_size": 80,
-          "col_size": 120                      
-        }
-      },
-      "lgn_spont": {
-        "node_set": "lgn",
-        "input": "spikes",
-        "module": "lgn_tf",
-        "stimulus_type": "grey_screen",
-        "stimulus_options": {
-          "row_size": 80,
-          "col_size": 120
-        }
-      },
-      "lgn_random": {
-        "node_set": "lgn",
-        "input": "spikes",
-        "module": "random",
-        "firing_rate": 20.0
-      },
-      "bkg_random": {
-        "node_set": "bkg",
-        "trainable": false,
-        "input": "spikes",
-        "module": "random",
-        "firing_rate": 10.0
+        "orientation": null,
+        "temporal_f": 2.0,
+        "row_size": 80,
+        "col_size": 120
       }
+    },
+    "lgn_spont": {
+      "node_set": "lgn",
+      "input": "spikes",
+      "module": "lgn_tf",
+      "stimulus_type": "grey_screen",
+      "stimulus_options": {
+        "row_size": 80,
+        "col_size": 120
+      }
+    },
+    "lgn_random": {
+      "node_set": "lgn",
+      "input": "spikes",
+      "module": "random",
+      "firing_rate": 20.0
+    },
+    "bkg_random": {
+      "node_set": "bkg",
+      "trainable": false,
+      "input": "spikes",
+      "module": "random",
+      "firing_rate": 10.0
+    }
   },
-
   "initial_states": {
     "zero_init_state": {
       "module": "zero_state"
     },
     "grey_screen_init_state": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_random"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_random"
+      ]
     }
   },
-
   "training": {
     "n_epochs": 2,
     "steps_per_epoch": 2,
@@ -104,9 +104,12 @@
     "initial_stateX": {
       "module": "zero_state"
     },
-    "initial_state":{
+    "initial_state": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_random"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_random"
+      ]
     },
     "callbacks": {
       "class": "Callbacks",
@@ -134,7 +137,7 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "drifting_gratings",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
@@ -168,23 +171,21 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "spontaneous",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           }
         }
       }
     ]
   },
-
   "inference": {
     "initial_state": {
-        "module": "zero_state"
+      "module": "zero_state"
     },
     "inputs": [
-        "lgn_random",
-        "bkg_random"
+      "lgn_random",
+      "bkg_random"
     ]
   },
-
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
@@ -193,12 +194,10 @@
     "voltages_file": "voltages.h5",
     "states_file": "model_state.h5"
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"      
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"
   },
-
   "networks": {
     "nodes": [
       {
@@ -216,7 +215,7 @@
     ],
     "edges": [
       {
-        "edges_file": "$NETWORK_DIR/v1_v1_edges.filtered.h5",
+        "edges_file": "$NETWORK_DIR/v1_v1_edges.h5",
         "edge_types_file": "$NETWORK_DIR/v1_v1_edge_types.csv"
       },
       {

--- a/examples/dpointnet_v1/configs/config.prediction.v1_dg.json
+++ b/examples/dpointnet_v1/configs/config.prediction.v1_dg.json
@@ -75,7 +75,7 @@
             "node_set": "bkg",
             "trainable": false,
             "input": "spikes",
-            "module": "noisy_current",
+            "module": "poisson_spikes",
             "seed": null,
             "firing_rate": 250.0
         }

--- a/examples/dpointnet_v1/configs/config.training.inseries.json
+++ b/examples/dpointnet_v1/configs/config.training.inseries.json
@@ -14,7 +14,7 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device",
     "checkpoint": {}
   },
@@ -28,7 +28,13 @@
     "pseudo_gauss": false,
     "lr_scale": 1.0,
     "max_delay": 5,
-    "hard_reset": false
+    "hard_reset": false,
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
   "training": {
     "n_epochs": 2,
@@ -44,7 +50,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_state": {
       "module": "zero_state"
@@ -70,15 +76,14 @@
             "node_set": "bkg",
             "trainable": false,
             "input": "spikes",
-            "module": "noisy_current",
-            "seed": null,
+            "module": "random",
             "firing_rate": 250.0
           }
         },
         "loss_functions": {
           "evoked_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -87,13 +92,13 @@
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
-            "voltage_cost": 1.5,
+            "voltage_cost": 1.0,
             "penalty_mode": "range"
           },
           "evoked_sync_loss": {
             "enabled": true,
             "module": "SynchronizationLoss",
-            "sync_cost": 1.0,
+            "sync_cost": 1.5,
             "t_start": 0.2,
             "t_end": 0.5,
             "n_samples": 500,
@@ -121,15 +126,14 @@
             "node_set": "bkg",
             "trainable": false,
             "input": "spikes",
-            "module": "noisy_current",
-            "seed": null,
+            "module": "random",
             "firing_rate": 250.0
           }
         },
         "loss_functions": {
           "spont_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -150,7 +154,7 @@
   },
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models"
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"
   },
   "networks": {
     "nodes": [

--- a/examples/dpointnet_v1/configs/config.training.inseries.json
+++ b/examples/dpointnet_v1/configs/config.training.inseries.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -18,11 +16,8 @@
     "train_recurrent_weights": true,
     "dtype": "float32",
     "single_gpu_strategy": "one_device",
-    "checkpoint": {
-        
-    }    
+    "checkpoint": {}
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -35,7 +30,6 @@
     "max_delay": 5,
     "hard_reset": false
   },
-
   "training": {
     "n_epochs": 2,
     "steps_per_epoch": 3,
@@ -66,20 +60,20 @@
             "module": "lgn_tf",
             "stimulus_type": "drifting_gratings",
             "stimulus_options": {
-                "orientation": null,
-                "temporal_f": 2.0,
-                "row_size": 80,
-                "col_size": 120                      
-              }
-            },
-            "bkg_inputs": {
-              "node_set": "bkg",
-              "trainable": false,
-              "input": "spikes",
-              "module": "noisy_current",
-              "seed": null,
-              "firing_rate": 250.0
+              "orientation": null,
+              "temporal_f": 2.0,
+              "row_size": 80,
+              "col_size": 120
             }
+          },
+          "bkg_inputs": {
+            "node_set": "bkg",
+            "trainable": false,
+            "input": "spikes",
+            "module": "noisy_current",
+            "seed": null,
+            "firing_rate": 250.0
+          }
         },
         "loss_functions": {
           "evoked_rate_regularizer": {
@@ -89,7 +83,7 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "drifting_gratings",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
@@ -140,29 +134,24 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "spontaneous",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           }
         }
       }
     ]
   },
-
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
     "log_level": "DEBUG",
     "spikes_file": "spikes_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
     "voltages_file": "voltages.h5_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
-    "callbacks": {
-
-    }
+    "callbacks": {}
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models"      
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models"
   },
-
   "networks": {
     "nodes": [
       {
@@ -184,7 +173,7 @@
     ],
     "edges": [
       {
-        "edges_file": "$NETWORK_DIR/v1_v1_edges.filtered.h5",
+        "edges_file": "$NETWORK_DIR/v1_v1_edges.h5",
         "edge_types_file": "$NETWORK_DIR/v1_v1_edge_types.csv"
       },
       {

--- a/examples/dpointnet_v1/configs/config.training.lgn_dg.evoked_only.json
+++ b/examples/dpointnet_v1/configs/config.training.lgn_dg.evoked_only.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -16,13 +14,10 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device",
-    "checkpoint": {
-        
-    }    
+    "checkpoint": {}
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -33,9 +28,14 @@
     "pseudo_gauss": false,
     "lr_scale": 1.0,
     "max_delay": 5,
-    "hard_reset": false
+    "hard_reset": false,
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
-
   "training": {
     "n_epochs": 3,
     "steps_per_epoch": 5,
@@ -49,7 +49,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_state": {
       "module": "zero_state"
@@ -65,49 +65,42 @@
             "module": "lgn_tf",
             "stimulus_type": "drifting_gratings",
             "stimulus_options": {
-                "orientation": null,
-                "temporal_f": 2.0,
-                "row_size": 80,
-                "col_size": 120                      
-              }
-            },
-            "bkg_inputs": {
-              "node_set": "bkg",
-              "trainable": false,
-              "input": "spikes",
-              "module": "noisy_current",
-              "seed": null,
-              "firing_rate": 250.0
+              "orientation": null,
+              "temporal_f": 2.0,
+              "row_size": 80,
+              "col_size": 120
             }
+          },
+          "bkg_inputs": {
+            "node_set": "bkg",
+            "trainable": false,
+            "input": "spikes",
+            "module": "random",
+            "firing_rate": 250.0
+          }
         },
         "loss_functions": {
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
-            "voltage_cost": 1.5,
+            "voltage_cost": 1.0,
             "penalty_mode": "range"
           }
         }
       }
     ]
   },
-
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
     "log_level": "DEBUG",
     "spikes_file": "spikes_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
     "voltages_file": "voltages.h5_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
-    "callbacks": {
-
-    }
+    "callbacks": {}
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models",
-    "basis_weights_file": "$BASE_DIR/synaptic_data/basis_function_weights.csv"
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"
   },
-
   "networks": {
     "nodes": [
       {

--- a/examples/dpointnet_v1/configs/config.training.lgn_dg.filtered.evoked_only.json
+++ b/examples/dpointnet_v1/configs/config.training.lgn_dg.filtered.evoked_only.json
@@ -14,7 +14,7 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device",
     "checkpoint": {}
   },
@@ -28,7 +28,13 @@
     "pseudo_gauss": false,
     "lr_scale": 1.0,
     "max_delay": 5,
-    "hard_reset": false
+    "hard_reset": false,
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
   "training": {
     "n_epochs": 3,
@@ -43,7 +49,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_state": {
       "module": "from_input",
@@ -67,8 +73,7 @@
           "node_set": "bkg",
           "trainable": false,
           "input": "spikes",
-          "module": "noisy_current",
-          "seed": null,
+          "module": "random",
           "firing_rate": 250.0
         }
       }
@@ -94,15 +99,14 @@
             "node_set": "bkg",
             "trainable": false,
             "input": "spikes",
-            "module": "noisy_current",
-            "seed": null,
+            "module": "random",
             "firing_rate": 250.0
           }
         },
         "loss_functions": {
           "evoked_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -123,7 +127,7 @@
   },
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models"
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"
   },
   "networks": {
     "nodes": [

--- a/examples/dpointnet_v1/configs/config.training.lgn_dg.filtered.evoked_only.json
+++ b/examples/dpointnet_v1/configs/config.training.lgn_dg.filtered.evoked_only.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -18,11 +16,8 @@
     "train_recurrent_weights": true,
     "dtype": "float32",
     "single_gpu_strategy": "one_device",
-    "checkpoint": {
-        
-    }    
+    "checkpoint": {}
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -35,7 +30,6 @@
     "max_delay": 5,
     "hard_reset": false
   },
-
   "training": {
     "n_epochs": 3,
     "steps_per_epoch": 5,
@@ -61,21 +55,21 @@
           "module": "lgn_tf",
           "stimulus_type": "gray_screen",
           "stimulus_options": {
-              "contrast": 0.0,
-              "row_size": 80,
-              "col_size": 120
+            "contrast": 0.0,
+            "row_size": 80,
+            "col_size": 120
           },
           "cell_params": {
-              "input_weight_scale": 1.0
+            "input_weight_scale": 1.0
           }
         },
         "bkg_inputs": {
-            "node_set": "bkg",
-            "trainable": false,
-            "input": "spikes",
-            "module": "noisy_current",
-            "seed": null,
-            "firing_rate": 250.0
+          "node_set": "bkg",
+          "trainable": false,
+          "input": "spikes",
+          "module": "noisy_current",
+          "seed": null,
+          "firing_rate": 250.0
         }
       }
     },
@@ -90,20 +84,20 @@
             "module": "lgn_tf",
             "stimulus_type": "drifting_gratings",
             "stimulus_options": {
-                "orientation": null,
-                "temporal_f": 2.0,
-                "row_size": 80,
-                "col_size": 120                      
-              }
-            },
-            "bkg_inputs": {
-              "node_set": "bkg",
-              "trainable": false,
-              "input": "spikes",
-              "module": "noisy_current",
-              "seed": null,
-              "firing_rate": 250.0
+              "orientation": null,
+              "temporal_f": 2.0,
+              "row_size": 80,
+              "col_size": 120
             }
+          },
+          "bkg_inputs": {
+            "node_set": "bkg",
+            "trainable": false,
+            "input": "spikes",
+            "module": "noisy_current",
+            "seed": null,
+            "firing_rate": 250.0
+          }
         },
         "loss_functions": {
           "evoked_rate_regularizer": {
@@ -113,29 +107,24 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "drifting_gratings",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           }
         }
       }
     ]
   },
-
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
     "log_level": "DEBUG",
     "spikes_file": "spikes_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
     "voltages_file": "voltages.h5_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
-    "callbacks": {
-
-    }
+    "callbacks": {}
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models"      
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models"
   },
-
   "networks": {
     "nodes": [
       {
@@ -157,7 +146,7 @@
     ],
     "edges": [
       {
-        "edges_file": "$NETWORK_DIR/v1_v1_edges.filtered.h5",
+        "edges_file": "$NETWORK_DIR/v1_v1_edges.h5",
         "edge_types_file": "$NETWORK_DIR/v1_v1_edge_types.csv"
       },
       {

--- a/examples/dpointnet_v1/configs/config.training.multispikes.batched.json
+++ b/examples/dpointnet_v1/configs/config.training.multispikes.batched.json
@@ -21,8 +21,8 @@
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
-    "dampening_factor": 0.3,
-    "recurrent_dampening_factor": 0.5,
+    "dampening_factor": 0.1,
+    "recurrent_dampening_factor": 0.1,
     "voltage_gradient_dampening": 0.5,
     "recurrent_weight_scale": 1.0,
     "pseudo_gauss": false,
@@ -61,10 +61,10 @@
     },
     "bkg_random": {
       "node_set": "bkg",
-      "trainable": false,
+      "trainable": true,
       "input": "spikes",
       "module": "random",
-      "firing_rate": 10.0
+      "firing_rate": 250.0
     }
   },
   "initial_states": {
@@ -84,16 +84,12 @@
     "steps_per_epoch": 2,
     "training_approach": "batched",
     "learning_rate": {
-      "schedule": "warmup_cosine",
-      "warmup_start_lr": 0.08,
-      "warmup_target_lr": 0.04,
-      "warmup_steps": 120,
-      "cosine_steps": 880,
-      "min_lr": 0.001
+      "schedule": "none",
+      "learning_rate": 0.005
     },
     "optimizer": {
-      "name": "adam",
-      "epsilon": 1e-07
+      "name": "exp_adam",
+      "epsilon": 1e-11
     },
     "initial_stateX": {
       "module": "zero_state"
@@ -130,13 +126,15 @@
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
+            "core_radius": 200.0,
             "stimulus_type": "drifting_gratings",
             "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
             "voltage_cost": 1.0,
-            "penalty_mode": "range"
+            "penalty_mode": "range",
+            "core_radius": 200.0
           },
           "evoked_sync_loss": {
             "enabled": true,
@@ -147,7 +145,8 @@
             "n_samples": 500,
             "stimulus_type": "drifting_gratings",
             "neuropixels_data_dir": "Synchronization_data",
-            "data_dir": "./GLIF_network"
+            "data_dir": "./GLIF_network",
+            "core_radius": 200.0
           }
         }
       },
@@ -164,6 +163,7 @@
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
+            "core_radius": 200.0,
             "stimulus_type": "spontaneous",
             "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           }

--- a/examples/dpointnet_v1/configs/config.training.multispikes.batched.json
+++ b/examples/dpointnet_v1/configs/config.training.multispikes.batched.json
@@ -14,7 +14,7 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device",
     "checkpoint": {}
   },
@@ -93,7 +93,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_stateX": {
       "module": "zero_state"
@@ -126,7 +126,7 @@
         "loss_functions": {
           "evoked_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -135,13 +135,13 @@
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
-            "voltage_cost": 1.5,
+            "voltage_cost": 1.0,
             "penalty_mode": "range"
           },
           "evoked_sync_loss": {
             "enabled": true,
             "module": "SynchronizationLoss",
-            "sync_cost": 1.0,
+            "sync_cost": 1.5,
             "t_start": 0.2,
             "t_end": 0.5,
             "n_samples": 500,
@@ -160,7 +160,7 @@
         "loss_functions": {
           "spont_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,

--- a/examples/dpointnet_v1/configs/config.training.multispikes.batched.json
+++ b/examples/dpointnet_v1/configs/config.training.multispikes.batched.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -18,11 +16,8 @@
     "train_recurrent_weights": true,
     "dtype": "float32",
     "single_gpu_strategy": "one_device",
-    "checkpoint": {
-        
-    }    
+    "checkpoint": {}
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -34,9 +29,13 @@
     "lr_scale": 1.0,
     "max_delay": 5,
     "hard_reset": false,
-    "tau_syns": [0.7579732, 1.60809441, 3.41168742, 7.23813909]
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
-
   "inputs": {
     "lgn_evoked": {
       "node_set": "lgn",
@@ -44,41 +43,42 @@
       "module": "lgn_tf",
       "stimulus_type": "drifting_gratings",
       "stimulus_options": {
-          "orientation": null,
-          "temporal_f": 2.0,
-          "row_size": 80,
-          "col_size": 120                      
-        }
-      },
-      "lgn_spont": {
-        "node_set": "lgn",
-        "input": "spikes",
-        "module": "lgn_tf",
-        "stimulus_type": "grey_screen",
-        "stimulus_options": {
-          "row_size": 80,
-          "col_size": 120
-        }
-      },
-      "bkg_random": {
-        "node_set": "bkg",
-        "trainable": false,
-        "input": "spikes",
-        "module": "random",
-        "firing_rate": 10.0
+        "orientation": null,
+        "temporal_f": 2.0,
+        "row_size": 80,
+        "col_size": 120
       }
+    },
+    "lgn_spont": {
+      "node_set": "lgn",
+      "input": "spikes",
+      "module": "lgn_tf",
+      "stimulus_type": "grey_screen",
+      "stimulus_options": {
+        "row_size": 80,
+        "col_size": 120
+      }
+    },
+    "bkg_random": {
+      "node_set": "bkg",
+      "trainable": false,
+      "input": "spikes",
+      "module": "random",
+      "firing_rate": 10.0
+    }
   },
-
   "initial_states": {
     "zero_init_state": {
       "module": "zero_state"
     },
     "grey_screen_init_state": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_random"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_random"
+      ]
     }
   },
-
   "training": {
     "n_epochs": 2,
     "steps_per_epoch": 2,
@@ -98,9 +98,12 @@
     "initial_stateX": {
       "module": "zero_state"
     },
-    "initial_state":{
+    "initial_state": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_random"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_random"
+      ]
     },
     "callbacks": {
       "class": "Callbacks",
@@ -128,7 +131,7 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "drifting_gratings",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
@@ -162,17 +165,13 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "spontaneous",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           }
         }
       }
     ]
   },
-
-  "inference": {
-
-  },
-
+  "inference": {},
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
@@ -180,12 +179,10 @@
     "spikes_file": "spikes_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
     "voltages_file": "voltages.h5_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5"
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"      
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"
   },
-
   "networks": {
     "nodes": [
       {
@@ -203,7 +200,7 @@
     ],
     "edges": [
       {
-        "edges_file": "$NETWORK_DIR/v1_v1_edges.filtered.h5",
+        "edges_file": "$NETWORK_DIR/v1_v1_edges.h5",
         "edge_types_file": "$NETWORK_DIR/v1_v1_edge_types.csv"
       },
       {

--- a/examples/dpointnet_v1/configs/config.training.multispikes.inseries.json
+++ b/examples/dpointnet_v1/configs/config.training.multispikes.inseries.json
@@ -14,7 +14,7 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device",
     "checkpoint": {}
   },
@@ -93,7 +93,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_stateX": {
       "module": "zero_state"
@@ -126,7 +126,7 @@
         "loss_functions": {
           "evoked_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -135,13 +135,13 @@
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
-            "voltage_cost": 1.5,
+            "voltage_cost": 1.0,
             "penalty_mode": "range"
           },
           "evoked_sync_loss": {
             "enabled": true,
             "module": "SynchronizationLoss",
-            "sync_cost": 1.0,
+            "sync_cost": 1.5,
             "t_start": 0.2,
             "t_end": 0.5,
             "n_samples": 500,
@@ -160,7 +160,7 @@
         "loss_functions": {
           "spont_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,

--- a/examples/dpointnet_v1/configs/config.training.multispikes.inseries.json
+++ b/examples/dpointnet_v1/configs/config.training.multispikes.inseries.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -18,11 +16,8 @@
     "train_recurrent_weights": true,
     "dtype": "float32",
     "single_gpu_strategy": "one_device",
-    "checkpoint": {
-        
-    }    
+    "checkpoint": {}
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -34,9 +29,13 @@
     "lr_scale": 1.0,
     "max_delay": 5,
     "hard_reset": false,
-    "tau_syns": [0.7579732, 1.60809441, 3.41168742, 7.23813909]
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
-
   "inputs": {
     "lgn_evoked": {
       "node_set": "lgn",
@@ -44,41 +43,42 @@
       "module": "lgn_tf",
       "stimulus_type": "drifting_gratings",
       "stimulus_options": {
-          "orientation": null,
-          "temporal_f": 2.0,
-          "row_size": 80,
-          "col_size": 120                      
-        }
-      },
-      "lgn_spont": {
-        "node_set": "lgn",
-        "input": "spikes",
-        "module": "lgn_tf",
-        "stimulus_type": "grey_screen",
-        "stimulus_options": {
-          "row_size": 80,
-          "col_size": 120
-        }
-      },
-      "bkg_random": {
-        "node_set": "bkg",
-        "trainable": false,
-        "input": "spikes",
-        "module": "random",
-        "firing_rate": 10.0
+        "orientation": null,
+        "temporal_f": 2.0,
+        "row_size": 80,
+        "col_size": 120
       }
+    },
+    "lgn_spont": {
+      "node_set": "lgn",
+      "input": "spikes",
+      "module": "lgn_tf",
+      "stimulus_type": "grey_screen",
+      "stimulus_options": {
+        "row_size": 80,
+        "col_size": 120
+      }
+    },
+    "bkg_random": {
+      "node_set": "bkg",
+      "trainable": false,
+      "input": "spikes",
+      "module": "random",
+      "firing_rate": 10.0
+    }
   },
-
   "initial_states": {
     "zero_init_state": {
       "module": "zero_state"
     },
     "grey_screen_init_state": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_random"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_random"
+      ]
     }
   },
-
   "training": {
     "n_epochs": 2,
     "steps_per_epoch": 2,
@@ -98,9 +98,12 @@
     "initial_stateX": {
       "module": "zero_state"
     },
-    "initial_state":{
+    "initial_state": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_random"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_random"
+      ]
     },
     "callbacks": {
       "class": "Callbacks",
@@ -128,7 +131,7 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "drifting_gratings",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
@@ -162,17 +165,13 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "spontaneous",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           }
         }
       }
     ]
   },
-
-  "inference": {
-
-  },
-
+  "inference": {},
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
@@ -180,12 +179,10 @@
     "spikes_file": "spikes_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
     "voltages_file": "voltages.h5_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5"
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"      
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"
   },
-
   "networks": {
     "nodes": [
       {
@@ -203,7 +200,7 @@
     ],
     "edges": [
       {
-        "edges_file": "$NETWORK_DIR/v1_v1_edges.filtered.h5",
+        "edges_file": "$NETWORK_DIR/v1_v1_edges.h5",
         "edge_types_file": "$NETWORK_DIR/v1_v1_edge_types.csv"
       },
       {

--- a/examples/dpointnet_v1/configs/config.training.simple.json
+++ b/examples/dpointnet_v1/configs/config.training.simple.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -19,7 +17,6 @@
     "dtype": "float32",
     "single_gpu_strategy": "one_device"
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -31,31 +28,33 @@
     "lr_scale": 1.0,
     "max_delay": 5,
     "hard_reset": false,
-    "tau_syns": [0.7579732, 1.60809441, 3.41168742, 7.23813909]
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
-
   "inputs": {
-      "lgn_random": {
-        "node_set": "lgn",
-        "input": "spikes",
-        "module": "random",
-        "firing_rate": 10.0
-      },
-      "bkg_random": {
-        "node_set": "bkg",
-        "trainable": false,
-        "input": "spikes",
-        "module": "random",
-        "firing_rate": 10.0
-      }
+    "lgn_random": {
+      "node_set": "lgn",
+      "input": "spikes",
+      "module": "random",
+      "firing_rate": 10.0
+    },
+    "bkg_random": {
+      "node_set": "bkg",
+      "trainable": false,
+      "input": "spikes",
+      "module": "random",
+      "firing_rate": 10.0
+    }
   },
-
   "initial_states": {
     "zero_init_state": {
       "module": "zero_state"
     }
   },
-
   "training": {
     "n_epochs": 1,
     "steps_per_epoch": 2,
@@ -75,9 +74,12 @@
     "initial_state": {
       "module": "zero_state"
     },
-    "initial_stateOLD":{
+    "initial_stateOLD": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_random"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_random"
+      ]
     },
     "callbacks": {
       "class": "Callbacks",
@@ -99,7 +101,7 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "drifting_gratings",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
@@ -121,23 +123,18 @@
       }
     ]
   },
-
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
     "log_level": "DEBUG",
     "spikes_file": "spikes_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
     "voltages_file": "voltages.h5_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
-    "callbacks": {
-
-    }
+    "callbacks": {}
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"      
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"
   },
-
   "networks": {
     "nodes": [
       {
@@ -155,7 +152,7 @@
     ],
     "edges": [
       {
-        "edges_file": "$NETWORK_DIR/v1_v1_edges.filtered.h5",
+        "edges_file": "$NETWORK_DIR/v1_v1_edges.h5",
         "edge_types_file": "$NETWORK_DIR/v1_v1_edge_types.csv"
       },
       {

--- a/examples/dpointnet_v1/configs/config.training.simple.json
+++ b/examples/dpointnet_v1/configs/config.training.simple.json
@@ -14,7 +14,7 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device"
   },
   "rnn_cell_params": {
@@ -69,7 +69,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_state": {
       "module": "zero_state"
@@ -96,7 +96,7 @@
         "loss_functions": {
           "evoked_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -105,13 +105,13 @@
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
-            "voltage_cost": 1.5,
+            "voltage_cost": 1.0,
             "penalty_mode": "range"
           },
           "evoked_sync_loss": {
             "enabled": true,
             "module": "SynchronizationLoss",
-            "sync_cost": 1.0,
+            "sync_cost": 1.5,
             "t_start": 0.2,
             "t_end": 0.5,
             "n_samples": 500,

--- a/examples/dpointnet_v1/configs/config.training.single.json
+++ b/examples/dpointnet_v1/configs/config.training.single.json
@@ -14,7 +14,7 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device"
   },
   "rnn_cell_params": {
@@ -49,7 +49,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_state": {
       "module": "zero_state"
@@ -76,15 +76,14 @@
             "node_set": "bkg",
             "trainable": false,
             "input": "spikes",
-            "module": "noisy_current",
-            "seed": null,
+            "module": "random",
             "firing_rate": 250.0
           }
         },
         "loss_functions": {
           "evoked_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -93,13 +92,13 @@
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
-            "voltage_cost": 1.5,
+            "voltage_cost": 1.0,
             "penalty_mode": "range"
           },
           "evoked_sync_loss": {
             "enabled": true,
             "module": "SynchronizationLoss",
-            "sync_cost": 1.0,
+            "sync_cost": 1.5,
             "t_start": 0.2,
             "t_end": 0.5,
             "n_samples": 500,

--- a/examples/dpointnet_v1/configs/config.training.single.json
+++ b/examples/dpointnet_v1/configs/config.training.single.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -19,7 +17,6 @@
     "dtype": "float32",
     "single_gpu_strategy": "one_device"
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -31,9 +28,13 @@
     "lr_scale": 1.0,
     "max_delay": 5,
     "hard_reset": false,
-    "tau_syns": [0.7579732, 1.60809441, 3.41168742, 7.23813909]
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
-
   "training": {
     "n_epochs": 2,
     "steps_per_epoch": 3,
@@ -65,20 +66,20 @@
             "module": "lgn_tf",
             "stimulus_type": "drifting_gratings",
             "stimulus_options": {
-                "orientation": null,
-                "temporal_f": 2.0,
-                "row_size": 80,
-                "col_size": 120                      
-              }
-            },
-            "bkg_inputs": {
-              "node_set": "bkg",
-              "trainable": false,
-              "input": "spikes",
-              "module": "noisy_current",
-              "seed": null,
-              "firing_rate": 250.0
+              "orientation": null,
+              "temporal_f": 2.0,
+              "row_size": 80,
+              "col_size": 120
             }
+          },
+          "bkg_inputs": {
+            "node_set": "bkg",
+            "trainable": false,
+            "input": "spikes",
+            "module": "noisy_current",
+            "seed": null,
+            "firing_rate": 250.0
+          }
         },
         "loss_functions": {
           "evoked_rate_regularizer": {
@@ -88,7 +89,7 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "drifting_gratings",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
@@ -110,23 +111,18 @@
       }
     ]
   },
-
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
     "log_level": "DEBUG",
     "spikes_file": "spikes_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
     "voltages_file": "voltages.h5_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
-    "callbacks": {
-
-    }
+    "callbacks": {}
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
-    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"      
+    "synaptic_models_dir": "$MODELS_DIR/synaptic_models_updated"
   },
-
   "networks": {
     "nodes": [
       {
@@ -148,7 +144,7 @@
     ],
     "edges": [
       {
-        "edges_file": "$NETWORK_DIR/v1_v1_edges.filtered.h5",
+        "edges_file": "$NETWORK_DIR/v1_v1_edges.h5",
         "edge_types_file": "$NETWORK_DIR/v1_v1_edge_types.csv"
       },
       {

--- a/examples/dpointnet_v1/configs/config.training.v1_dg.json
+++ b/examples/dpointnet_v1/configs/config.training.v1_dg.json
@@ -14,7 +14,7 @@
     "t_start": 0.0,
     "default_seed": 3000,
     "train_recurrent_weights": true,
-    "dtype": "float32",
+    "dtype": "float16",
     "single_gpu_strategy": "one_device"
   },
   "rnn_cell_params": {
@@ -62,8 +62,7 @@
       "node_set": "bkg",
       "trainable": false,
       "input": "spikes",
-      "module": "noisy_current",
-      "seed": null,
+      "module": "random",
       "firing_rate": 250.0
     }
   },
@@ -93,7 +92,7 @@
     },
     "optimizer": {
       "name": "adam",
-      "epsilon": 1.0e-07
+      "epsilon": 1e-07
     },
     "initial_state": {
       "module": "from_input",
@@ -112,7 +111,7 @@
         "loss_functions": {
           "evoked_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,
@@ -121,13 +120,13 @@
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
-            "voltage_cost": 1.5,
+            "voltage_cost": 1.0,
             "penalty_mode": "range"
           },
           "evoked_sync_loss": {
             "enabled": true,
             "module": "SynchronizationLoss",
-            "sync_cost": 1.0,
+            "sync_cost": 1.5,
             "t_start": 0.2,
             "t_end": 0.5,
             "n_samples": 500,
@@ -146,7 +145,7 @@
         "loss_functions": {
           "spont_rate_regularizer": {
             "module": "SpikeRateDistributionTarget",
-            "rate_cost": 100.0,
+            "rate_cost": 10000.0,
             "pre_delay": 100.0,
             "post_delay": 0.0,
             "core_mask": null,

--- a/examples/dpointnet_v1/configs/config.training.v1_dg.json
+++ b/examples/dpointnet_v1/configs/config.training.v1_dg.json
@@ -6,9 +6,7 @@
     "$NETWORK_DIR": "$BASE_DIR/GLIF_network/network",
     "$MODELS_DIR": "$BASE_DIR/GLIF_network/components"
   },
-  
   "target_simulator": "RNN",
-
   "run": {
     "seq_len": 500,
     "dt": 1.0,
@@ -19,7 +17,6 @@
     "dtype": "float32",
     "single_gpu_strategy": "one_device"
   },
-  
   "rnn_cell_params": {
     "cell_model": "GLIF3Cell",
     "gauss_std": 0.5,
@@ -31,7 +28,12 @@
     "lr_scale": 1.0,
     "max_delay": 5,
     "hard_reset": false,
-    "tau_syns": [0.7579732, 1.60809441, 3.41168742, 7.23813909]
+    "tau_syns": [
+      0.7579732,
+      1.60809441,
+      3.41168742,
+      7.23813909
+    ]
   },
   "inputs": {
     "lgn_evoked": {
@@ -40,42 +42,43 @@
       "module": "lgn_tf",
       "stimulus_type": "drifting_gratings",
       "stimulus_options": {
-          "orientation": null,
-          "temporal_f": 2.0,
-          "row_size": 80,
-          "col_size": 120                      
-        }
-      },
-      "lgn_spont": {
-        "node_set": "lgn",
-        "input": "spikes",
-        "module": "lgn_tf",
-        "stimulus_type": "grey_screen",
-        "stimulus_options": {
-          "row_size": 80,
-          "col_size": 120
-        }
-      },
-      "bkg_inputs": {
-        "node_set": "bkg",
-        "trainable": false,
-        "input": "spikes",
-        "module": "noisy_current",
-        "seed": null,
-        "firing_rate": 250.0
+        "orientation": null,
+        "temporal_f": 2.0,
+        "row_size": 80,
+        "col_size": 120
       }
+    },
+    "lgn_spont": {
+      "node_set": "lgn",
+      "input": "spikes",
+      "module": "lgn_tf",
+      "stimulus_type": "grey_screen",
+      "stimulus_options": {
+        "row_size": 80,
+        "col_size": 120
+      }
+    },
+    "bkg_inputs": {
+      "node_set": "bkg",
+      "trainable": false,
+      "input": "spikes",
+      "module": "noisy_current",
+      "seed": null,
+      "firing_rate": 250.0
+    }
   },
-
   "initial_states": {
     "zero_init_state": {
       "module": "zero_state"
     },
     "grey_screen_init_state": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_inputs"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_inputs"
+      ]
     }
   },
-
   "training": {
     "n_epochs": 2,
     "steps_per_epoch": 3,
@@ -92,9 +95,12 @@
       "name": "adam",
       "epsilon": 1.0e-07
     },
-    "initial_state":{
+    "initial_state": {
       "module": "from_input",
-      "inputs": ["lgn_spont", "bkg_inputs"]
+      "inputs": [
+        "lgn_spont",
+        "bkg_inputs"
+      ]
     },
     "parameters": [
       {
@@ -111,7 +117,7 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "drifting_gratings",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           },
           "evoked_voltage_regularizer": {
             "module": "VoltageRegularization",
@@ -145,13 +151,12 @@
             "post_delay": 0.0,
             "core_mask": null,
             "stimulus_type": "spontaneous",
-            "neuropixels_df": "$BASE_DIR/Neuropixels_data/v1_OSI_DSI_DF.csv"
+            "neuropixels_df": "$BASE_DIR/Neuropixels_data/OSI_DSI_neuropixels_v4.csv.gz"
           }
         }
       }
     ]
   },
-
   "output": {
     "output_dir": "$OUTPUT_DIR",
     "log_file": "log.txt",
@@ -159,13 +164,11 @@
     "spikes_file": "spikes_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5",
     "voltages_file": "voltages.h5_ori${matrix:angle}_tf${matrix:tf}_${bmtk:batch_num}.h5"
   },
-
   "components": {
     "point_neuron_models_dir": "$MODELS_DIR/cell_models",
     "synaptic_models_dir": "$MODELS_DIR/synaptic_models",
     "basis_weights_file": "$MODELS_DIR/synaptic_data/basis_function_weights.csv"
   },
-
   "networks": {
     "nodes": [
       {
@@ -186,7 +189,7 @@
     ],
     "edges": [
       {
-        "edges_file": "$NETWORK_DIR/v1_v1_edges.filtered.h5",
+        "edges_file": "$NETWORK_DIR/v1_v1_edges.h5",
         "edge_types_file": "$NETWORK_DIR/v1_v1_edge_types.csv"
       },
       {

--- a/examples/dpointnet_v1/run_dpointnet.inference.py
+++ b/examples/dpointnet_v1/run_dpointnet.inference.py
@@ -1,16 +1,24 @@
 import argparse
+import os
+import sys
+import traceback
 
 from bmtk.simulator import dpointnet
 
 
 def run(config_path):
+    rnn_network = None
     config = dpointnet.Config.from_json(config_path)
     config.build_env()
 
-    rnn_network = dpointnet.RNN.from_config(config)
-    rnn_network.build()
-    results = rnn_network.run_inference()
-    print(results)
+    try:
+        rnn_network = dpointnet.RNN.from_config(config)
+        rnn_network.build()
+        results = rnn_network.run_inference()
+        print(results)
+    finally:
+        if rnn_network is not None:
+            rnn_network.cleanup()
     # rnn_network.save_weights()
     # rnn_network.predict()
     # results = rnn_network.inference()
@@ -29,4 +37,13 @@ if __name__ == '__main__':
     )
 
     args, _ = parser.parse_known_args()
-    run(args.config_path)
+    try:
+        run(args.config_path)
+    except Exception:
+        traceback.print_exc()
+        dpointnet.cleanup_tensorflow()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1)
+    finally:
+        dpointnet.cleanup_tensorflow()

--- a/examples/dpointnet_v1/run_dpointnet.py
+++ b/examples/dpointnet_v1/run_dpointnet.py
@@ -1,14 +1,22 @@
 import argparse
+import os
+import sys
+import traceback
 
 from bmtk.simulator import dpointnet
 
 
 def run(config_path):
+    rnn_network = None
     config = dpointnet.Config.from_json(config_path)
     config.build_env()
 
-    rnn_network = dpointnet.RNN.from_config(config)
-    rnn_network.run()
+    try:
+        rnn_network = dpointnet.RNN.from_config(config)
+        rnn_network.run()
+    finally:
+        if rnn_network is not None:
+            rnn_network.cleanup()
     # rnn_network.save_weights()
     # rnn_network.predict()
     # results = rnn_network.inference()
@@ -27,4 +35,13 @@ if __name__ == '__main__':
     )
 
     args, _ = parser.parse_known_args()
-    run(args.config_path)
+    try:
+        run(args.config_path)
+    except Exception:
+        traceback.print_exc()
+        dpointnet.cleanup_tensorflow()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1)
+    finally:
+        dpointnet.cleanup_tensorflow()

--- a/examples/dpointnet_v1/run_dpointnet.train.py
+++ b/examples/dpointnet_v1/run_dpointnet.train.py
@@ -1,15 +1,23 @@
 import argparse
+import os
+import sys
+import traceback
 
 from bmtk.simulator import dpointnet
 
 
 def run(config_path):
+    rnn_network = None
     config = dpointnet.Config.from_json(config_path)
     config.build_env()
 
-    rnn_network = dpointnet.RNN.from_config(config)
-    rnn_network.build()
-    rnn_network.train()
+    try:
+        rnn_network = dpointnet.RNN.from_config(config)
+        rnn_network.build()
+        rnn_network.train()
+    finally:
+        if rnn_network is not None:
+            rnn_network.cleanup()
     # rnn_network.save_weights()
     # rnn_network.predict()
     # results = rnn_network.inference()
@@ -28,4 +36,13 @@ if __name__ == '__main__':
     )
 
     args, _ = parser.parse_known_args()
-    run(args.config_path)
+    try:
+        run(args.config_path)
+    except Exception:
+        traceback.print_exc()
+        dpointnet.cleanup_tensorflow()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1)
+    finally:
+        dpointnet.cleanup_tensorflow()


### PR DESCRIPTION
Builds on feature/dpointnet (incl. Kael's GLIF3Cell `current_factor` init fix, merged in).
Gets the dpointnet (TF/Keras) V1 GLIF port to (a) run inference matching the NEST
point-net, and (b) train firing rates at the reference learning rate. 14 core files
(+480/−113) plus example configs.

### Runtime / memory
- **OOM fix** (`0821696b`): `OneDeviceStrategy` → `MirroredStrategy`, and build the model
  inside `strategy.scope()`. Full 66k-neuron net now fits the 24 GB card (~17 GB).
- **float16 / mixed precision** (`c0dfd911`): dtype casts for `decay`/`current_factor`;
  `LossScaleOptimizer` set back on the training engine; loss accumulation cast to float32;
  added Grappler/XLA optimization toggles in `tf_utils`.

### Inference correctness
- **Input-current path** (`dff4ed09`): `calculate_input_current_from_spikes`
  (multi-spike aware) and `calculate_input_current_from_firing_probabilities`, selected per
  input via `input_type` ('spikes' | 'current'). This is what brings V1 firing into the
  physiological range; verified against a NEST/PointNet run of the same network
  (gray ≈0.4 Hz, gratings ≈1.0 Hz; per-population rates and silent fractions match within a
  few %).

### Training
- **Batched-step slicing fix** (`c0dfd911`): `pidx_beg` was never advanced in
  `_train_step_batched`, so the 2nd parameter's losses used the wrong spike slice.
- **Recurrent-weight shadow** (`c0dfd911`): non-trainable compute-dtype shadow of the
  recurrent weights, refreshed after each optimizer step (`refresh_recurrent_weight_shadow`),
  so the fp16 forward sees updated weights.
- **Trainable background weights** (`fd19d249`): input weight trainability now follows the
  config (previously the per-input `trainable` flag was a no-op because the network options
  were overwritten). Enables training the background "rest_of_brain" weights, matching the
  reference's `train_noise` — a major, efficient knob on firing rate that was unused.
- **Per-loss `core_radius`** (`fd19d249`): `SpikeRateDistributionTarget`,
  `SynchronizationLoss`, `VoltageRegularization` can restrict to a central core
  (matches reference `loss_core_radius`); `isolate_core_neurons` falls back to identity
  neuron order when the network has no `tf_id_to_bmtk_id`.

With these, dpointnet training reduces the loss at the reference's lr=0.005 (rate loss
descends comparably to V1_GLIF_model), whereas before it was flat/diverging.

### Not included / known follow-ups
- `osi_dsi` loss is intentionally omitted for now.
- `VoltageRegularization` currently yields zero gradient to the recurrent weights vs the
  reference — flagged for a follow-up.
- The multi-spike `n_pre_spikes` scaling in the input current is a deliberate forward
  difference from the reference's binary treatment.

All code changes are additive/backward-compatible (`core_radius` defaults to None; input
trainability acts only when the config sets it).
