### PR TITLE
Enabling multi-parameter inference and fixed phase lgn runs

### DIFF
--- a/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
+++ b/bmtk/simulator/dpointnet/cell_models/glif3_cell.py
@@ -12,6 +12,15 @@ try:
 except Exception:
     HAS_NUMBA = False
 
+    def njit(*args, **kwargs):
+        if args and callable(args[0]) and len(args) == 1 and not kwargs:
+            return args[0]
+
+        def decorator(func):
+            return func
+
+        return decorator
+
 
 def make_pre_ind_table(indices, n_source_neurons):
     # Validate inputs
@@ -404,6 +413,21 @@ def straight_through_dampen(x, dampening):
 
 
 class GLIF3Cell(tf.keras.layers.Layer):
+    def _tracked_weight(self, initial_value, name, trainable, dtype, constraint=None):
+        initial_value = np.asarray(initial_value)
+        return self.add_weight(
+            name=name,
+            shape=initial_value.shape,
+            dtype=dtype,
+            initializer=tf.keras.initializers.Constant(initial_value),
+            trainable=trainable,
+            constraint=constraint,
+        )
+
+    def _untracked_variable(self, variable):
+        return variable
+
+
     def __init__(
             self, 
             glif_network,
@@ -597,7 +621,7 @@ class GLIF3Cell(tf.keras.layers.Layer):
             individual_training = False
             per_type_training = False
 
-        self.recurrent_weight_values = tf.Variable(
+        self.recurrent_weight_values = self._tracked_weight(
             weights * recurrent_weight_scale / lr_scale,
             name="sparse_recurrent_weights",
             constraint=SignedConstraint(recurrent_weight_positive),
@@ -620,7 +644,7 @@ class GLIF3Cell(tf.keras.layers.Layer):
                 dtype=self.compute_dtype,
             )
             # Keep untracked so older checkpoints remain loadable with assert_consumed().
-            self.recurrent_weight_values_compute = self._no_dependency(recurrent_weight_values_compute)
+            self.recurrent_weight_values_compute = self._untracked_variable(recurrent_weight_values_compute)
         else:
             self.recurrent_weight_values_compute = self.recurrent_weight_values
 
@@ -659,7 +683,7 @@ class GLIF3Cell(tf.keras.layers.Layer):
             input_weight_positive = tf.constant(input_weights >= 0, dtype=tf.bool)
             input_trainable = input_options.get('trainable', False)
 
-            input_props['input_weight_values'] = tf.Variable(
+            input_props['input_weight_values'] = self._tracked_weight(
                 input_weights * input_options.get('weight_scale', 1.0) / lr_scale,
                 name=f'{input_name}_input_weights',
                 constraint=SignedConstraint(input_weight_positive),
@@ -677,7 +701,7 @@ class GLIF3Cell(tf.keras.layers.Layer):
                     trainable=False,
                     dtype=self.compute_dtype,
                 )
-                input_props['input_weight_values_compute'] = self._no_dependency(_input_weight_compute)
+                input_props['input_weight_values_compute'] = self._untracked_variable(_input_weight_compute)
             else:
                 input_props['input_weight_values_compute'] = input_props['input_weight_values']
             input_props['input_syn_ids'] = tf.constant(input_syn_ids, dtype=tf.int64) # for efficiency this needs to be in int64
@@ -889,10 +913,15 @@ class GLIF3Cell(tf.keras.layers.Layer):
         # new_v = self.decay * dampened_v + self.current_factor * c1 - prev_z
         # Update the voltage according to the LIF equation and the refractory period
         # New r is a variable that accounts for the refractory period in which a neuron cannot spike
-        # prev_spike = tf.cast(prev_z > 0, self._refractory_state_dtype)
-        prev_spike = tf.cast(prev_z, dtype=self._refractory_state_dtype)
-        # new_r = tf.maximum(r + prev_spike * self.t_ref_steps - 1, 0)
-        new_r = tf.stop_gradient(tf.maximum(r + prev_spike * self.t_ref_steps - 1, 0)) # prevent gradients from flowing through the refractory state
+        refractory_dtype = r.dtype
+        prev_spike = tf.cast(prev_z, dtype=refractory_dtype)
+        t_ref_steps = tf.cast(self.t_ref_steps, dtype=refractory_dtype)
+        new_r = tf.stop_gradient(
+            tf.maximum(
+                r + prev_spike * t_ref_steps - tf.cast(1, refractory_dtype),
+                tf.cast(0, refractory_dtype)
+            )
+        ) # prevent gradients from flowing through the refractory state
 
         if self._hard_reset:
             # Here we keep the voltage at the reset value during the refractory period
@@ -1037,16 +1066,15 @@ class GLIF3Cell(tf.keras.layers.Layer):
         # Add current spikes to the buffer
         new_z_buf = tf.concat([new_z, z_buf[:, :-self._n_neurons]], axis=1)  # Shift buffer
 
-        outputs = (
-            new_z,
-            new_v,
-            # new_v * self.voltage_scale + self.voltage_offset,
-            # (input_current + tf.reduce_sum(asc, axis=-1)) * self.voltage_scale,
-        )
+        outputs = tf.concat([new_z, new_v], axis=-1)
         # Increment persistent noise_step counter (never reset across epochs)
         self.noise_step.assign_add(1)
         new_state = (new_z_buf, new_v, new_r, new_asc, new_psc_rise, new_psc)
         return outputs, new_state
+
+    @property
+    def output_size(self):
+        return self._n_neurons * 2
 
     @property
     def state_size(self):

--- a/bmtk/simulator/dpointnet/input_modules/lgn_generator.py
+++ b/bmtk/simulator/dpointnet/input_modules/lgn_generator.py
@@ -256,7 +256,6 @@ def create_drifting_gratings_generator(
         lgn_network,
         seq_len,
         orientation=None, 
-    phase=None,
         temporal_f=2, 
         cpd=0.04, 
         contrast=0.8,                             
@@ -271,7 +270,8 @@ def create_drifting_gratings_generator(
         rotation='ccw',  # match reference V1_GLIF_model default (flags.rotation='ccw'); cw flips drift/orientation vs the OSI-loss tuning-angle convention
         billeh_phase=False,
         dtype=tf.float32,
-        seed=None):
+        seed=None,
+        phase=None):
 
     # lgn = LGN(
     #     network=network,
@@ -332,7 +332,7 @@ def create_drifting_gratings_generator(
 
             # Generate a random phase (reference-matched stateless schedule)
             if fixed_phase is not None:
-                phase = fixed_phase
+                phase = tf.cast(fixed_phase, dtype)
             elif phase_seed is None:
                 phase = tf.random.uniform(shape=[], minval=0, maxval=360, dtype=dtype)
             else:

--- a/bmtk/simulator/dpointnet/input_modules/lgn_generator.py
+++ b/bmtk/simulator/dpointnet/input_modules/lgn_generator.py
@@ -256,6 +256,7 @@ def create_drifting_gratings_generator(
         lgn_network,
         seq_len,
         orientation=None, 
+    phase=None,
         temporal_f=2, 
         cpd=0.04, 
         contrast=0.8,                             
@@ -288,6 +289,8 @@ def create_drifting_gratings_generator(
         orientation_list_len = len(orientation)
     else:
         orientation_list_len = -1
+
+    fixed_phase = phase
 
     def _g():
         if regular:
@@ -328,7 +331,9 @@ def create_drifting_gratings_generator(
             mov_theta = tf.cast(mov_theta, dtype)
 
             # Generate a random phase (reference-matched stateless schedule)
-            if phase_seed is None:
+            if fixed_phase is not None:
+                phase = fixed_phase
+            elif phase_seed is None:
                 phase = tf.random.uniform(shape=[], minval=0, maxval=360, dtype=dtype)
             else:
                 phase = tf.random.stateless_uniform(

--- a/bmtk/simulator/dpointnet/loss_functions/orientation_selectivity_loss.py
+++ b/bmtk/simulator/dpointnet/loss_functions/orientation_selectivity_loss.py
@@ -79,7 +79,8 @@ class OrientationSelectivityLoss:
             post_delay=self._post_delay,
             trim=trim,
         )
-        evoked_rates = tf.cast(tf.reduce_mean(spikes, axis=[0, 1]), tf.float32)
+        leading_axes = tf.range(tf.maximum(tf.rank(spikes) - 1, 0))
+        evoked_rates = tf.cast(tf.reduce_mean(spikes, axis=leading_axes), tf.float32)
         v1_ema = normalizers['v1_ema']
         v1_ema.assign(self._ema_decay * v1_ema + (1.0 - self._ema_decay) * evoked_rates)
     

--- a/bmtk/simulator/dpointnet/loss_functions/spike_rate_distribution_target.py
+++ b/bmtk/simulator/dpointnet/loss_functions/spike_rate_distribution_target.py
@@ -134,7 +134,8 @@ class SpikeRateDistributionTarget:
         if spikes.dtype != self._dtype:
             spikes = tf.cast(spikes, self._dtype)
 
-        rates = tf.reduce_mean(spikes, (0, 1)) # calculate the mean firing rate over time and batch
+        leading_axes = tf.range(tf.maximum(tf.rank(spikes) - 1, 0))
+        rates = tf.reduce_mean(spikes, axis=leading_axes) # calculate the mean firing rate over time and batch
 
         reg_loss = loss_utils.compute_spike_rate_target_loss(rates, self._target_rates, dtype=self._dtype)
         if self._annulus_target_rates is not None:

--- a/bmtk/simulator/dpointnet/loss_functions/synchronization_loss.py
+++ b/bmtk/simulator/dpointnet/loss_functions/synchronization_loss.py
@@ -37,6 +37,9 @@ class SynchronizationLoss(tf.keras.layers.Layer):
         self._core_mask = loss_utils.resolve_core_mask(
             self._network, core_mask, kwargs.get('core_radius'), data_dir
         )
+        self._core_indices = None
+        if self._core_mask is not None:
+            self._core_indices = tf.constant(np.flatnonzero(self._core_mask), dtype=tf.int32)
         self._neuropixels_data_dir = neuropixels_data_dir
         self._dtype = dtype
         self._n_samples = n_samples
@@ -107,8 +110,19 @@ class SynchronizationLoss(tf.keras.layers.Layer):
         return fanos.stack()
     
     def __call__(self, spikes, trim=True, **kwargs):
-        if self._core_mask is not None:
-            spikes = tf.boolean_mask(spikes, self._core_mask, axis=2)
+        spikes = tf.convert_to_tensor(spikes)
+        if spikes.shape.rank is None:
+            spikes = tf.cond(
+                tf.equal(tf.rank(spikes), 2),
+                lambda: tf.expand_dims(spikes, axis=0),
+                lambda: spikes,
+            )
+            spikes.set_shape([None, None, None])
+        elif spikes.shape.rank == 2:
+            spikes = tf.expand_dims(spikes, axis=0)
+
+        if self._core_indices is not None:
+            spikes = tf.gather(spikes, self._core_indices, axis=2)
         
         if trim:
             spikes = spikes[:, self._t_start_idx:self._t_end_idx, :]

--- a/bmtk/simulator/dpointnet/loss_functions/voltage_regularization.py
+++ b/bmtk/simulator/dpointnet/loss_functions/voltage_regularization.py
@@ -22,9 +22,7 @@ class VoltageRegularization:
 
     @tf.function(jit_compile=True)
     def _safe_global_mean(self, penalty):
-        penalty = tf.reduce_mean(penalty, axis=0)
-        penalty = tf.reduce_mean(penalty, axis=0)
-        return tf.reduce_mean(tf.cast(penalty, tf.float32), axis=0)
+        return tf.reduce_mean(tf.cast(penalty, tf.float32))
 
     @tf.function(jit_compile=True)
     def _compute_range_loss(self, voltages):

--- a/bmtk/simulator/dpointnet/loss_functions/weight_regularization.py
+++ b/bmtk/simulator/dpointnet/loss_functions/weight_regularization.py
@@ -111,4 +111,4 @@ class EMDWeightRegularization:
     def __call__(self, **kwargs):
         # Weight regularizer: independent of activity (spikes/voltages). Reads the current
         # trainable recurrent weights so gradients flow back to them.
-        return self._compute(self._weights)
+        return self._compute(tf.convert_to_tensor(self._weights))

--- a/bmtk/simulator/dpointnet/optimizers.py
+++ b/bmtk/simulator/dpointnet/optimizers.py
@@ -1,5 +1,11 @@
+import inspect
+
 import tensorflow as tf
 import math
+
+
+def _optimizer_init_accepts(argument_name):
+    return argument_name in inspect.signature(tf.keras.optimizers.Optimizer.__init__).parameters
 
 
 def build_learning_rate(lr_schedule, **lr_params):
@@ -17,17 +23,22 @@ def build_learning_rate(lr_schedule, **lr_params):
 
 
 def optimizer_supports_loss_scaling(optimizer):
-    return hasattr(optimizer, 'get_scaled_loss') and hasattr(optimizer, 'get_unscaled_gradients')
+    return (
+        hasattr(optimizer, 'scale_loss') or
+        (hasattr(optimizer, 'get_scaled_loss') and hasattr(optimizer, 'get_unscaled_gradients'))
+    )
 
 
 def scale_loss_for_optimizer(optimizer, loss):
-    if optimizer_supports_loss_scaling(optimizer):
+    if hasattr(optimizer, 'scale_loss'):
+        return optimizer.scale_loss(loss)
+    if hasattr(optimizer, 'get_scaled_loss'):
         return optimizer.get_scaled_loss(loss)
     return loss
 
 
 def unscale_gradients_for_optimizer(optimizer, gradients):
-    if optimizer_supports_loss_scaling(optimizer):
+    if hasattr(optimizer, 'get_unscaled_gradients'):
         return optimizer.get_unscaled_gradients(gradients)
     
     return gradients
@@ -172,7 +183,7 @@ class ExponentiatedAdam(tf.keras.optimizers.Optimizer):
         **kwargs
     ):
         """Create a new ExponentiatedAdam optimizer."""
-        super().__init__(
+        base_kwargs = dict(
             name=name,
             weight_decay=weight_decay,
             clipnorm=clipnorm,
@@ -181,14 +192,36 @@ class ExponentiatedAdam(tf.keras.optimizers.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
-            jit_compile=jit_compile,
             **kwargs
         )
-        self._learning_rate = self._build_learning_rate(learning_rate)
+        if _optimizer_init_accepts('jit_compile'):
+            base_kwargs['jit_compile'] = jit_compile
+        try:
+            super().__init__(learning_rate=learning_rate, **base_kwargs)
+        except TypeError as exc:
+            if 'learning_rate' not in str(exc):
+                raise
+            super().__init__(**base_kwargs)
+            self._learning_rate = self._build_learning_rate(learning_rate)
         self.beta_1 = beta_1
         self.beta_2 = beta_2
         self.epsilon = epsilon
         self.amsgrad = amsgrad
+
+    def _add_slot_variable(self, variable, name):
+        try:
+            return self.add_variable_from_reference(
+                model_variable=variable, variable_name=name
+            )
+        except TypeError:
+            return self.add_variable_from_reference(
+                reference_variable=variable, name=name
+            )
+
+    def _get_variable_index(self, variable):
+        if hasattr(tf.keras.optimizers.Optimizer, '_get_variable_index'):
+            return super()._get_variable_index(variable)
+        return self._index_dict[self._var_key(variable)]
 
     def build(self, var_list):
         """Initialize optimizer variables.
@@ -198,31 +231,19 @@ class ExponentiatedAdam(tf.keras.optimizers.Optimizer):
         - v (second moment)
         - vhat (if amsgrad=True, for the max of second moments).
         """
-        super().build(var_list)
-        if hasattr(self, "_built") and self._built:
+        if getattr(self, "_slots_built", False):
             return
-        self._built = True
+        super().build(var_list)
+        self._slots_built = True
         self._momentums = []
         self._velocities = []
         for var in var_list:
-            self._momentums.append(
-                self.add_variable_from_reference(
-                    model_variable=var, variable_name="m"
-                )
-            )
-            self._velocities.append(
-                self.add_variable_from_reference(
-                    model_variable=var, variable_name="v"
-                )
-            )
+            self._momentums.append(self._add_slot_variable(var, "m"))
+            self._velocities.append(self._add_slot_variable(var, "v"))
         if self.amsgrad:
             self._velocity_hats = []
             for var in var_list:
-                self._velocity_hats.append(
-                    self.add_variable_from_reference(
-                        model_variable=var, variable_name="vhat"
-                    )
-                )
+                self._velocity_hats.append(self._add_slot_variable(var, "vhat"))
 
     def _coalesce_indexed_slices(self, grad, variable_dtype=None, index_dtype=tf.int32):
         """Coalesce duplicate indices in an IndexedSlices gradient."""
@@ -243,8 +264,7 @@ class ExponentiatedAdam(tf.keras.optimizers.Optimizer):
 
         return tf.IndexedSlices(coalesced_values, unique_idx, dense_shape)
 
-    @tf.function(jit_compile=True)
-    def update_step(self, gradient, variable):
+    def update_step(self, gradient, variable, learning_rate=None):
         """Update step given gradient and the associated model variable."""
         # if isinstance(gradient, tf.IndexedSlices):
         #     gradient = tf.convert_to_tensor(gradient)
@@ -257,14 +277,16 @@ class ExponentiatedAdam(tf.keras.optimizers.Optimizer):
         beta_2_power = tf.pow(beta_2_t, local_step)
 
         # Get the current learning rate (supports schedules)
-        lr = tf.cast(self.learning_rate, variable.dtype)
+        if learning_rate is None:
+            learning_rate = self.learning_rate
+        lr = tf.cast(learning_rate, variable.dtype)
         # Standard Adam alpha correction
         alpha = lr * tf.sqrt(1 - beta_2_power) / (1 - beta_1_power)
 
         # Fetch the slot variables for this parameter
-        var_key = self._var_key(variable)
-        m = self._momentums[self._index_dict[var_key]]
-        v = self._velocities[self._index_dict[var_key]]
+        var_index = self._get_variable_index(variable)
+        m = self._momentums[var_index]
+        v = self._velocities[var_index]
 
         # ------------------------
         # Sparse vs. Dense branch
@@ -295,7 +317,7 @@ class ExponentiatedAdam(tf.keras.optimizers.Optimizer):
             )
             # 3) AMSGrad if needed
             if self.amsgrad:
-                vhat = self._velocity_hats[self._index_dict[var_key]]
+                vhat = self._velocity_hats[var_index]
                 vhat.assign(tf.maximum(vhat, v))
                 v_used = vhat
             else:
@@ -337,7 +359,7 @@ class ExponentiatedAdam(tf.keras.optimizers.Optimizer):
             v.assign_add((tf.square(gradient) - v) * (1 - beta_2_t))
             # 3) AMSGrad
             if self.amsgrad:
-                vhat = self._velocity_hats[self._index_dict[var_key]]
+                vhat = self._velocity_hats[var_index]
                 vhat.assign(tf.maximum(vhat, v))
                 v_used = vhat
             else:
@@ -356,11 +378,13 @@ class ExponentiatedAdam(tf.keras.optimizers.Optimizer):
 
     def get_config(self):
         config = super().get_config()
+        if hasattr(self, '_serialize_hyperparameter') and hasattr(self, '_learning_rate'):
+            learning_rate = self._serialize_hyperparameter(self._learning_rate)
+        else:
+            learning_rate = config.get('learning_rate', self.learning_rate)
         config.update(
             {
-                "learning_rate": self._serialize_hyperparameter(
-                    self._learning_rate
-                ),
+                "learning_rate": learning_rate,
                 "beta_1": self.beta_1,
                 "beta_2": self.beta_2,
                 "epsilon": self.epsilon,

--- a/bmtk/simulator/dpointnet/rnn_model.py
+++ b/bmtk/simulator/dpointnet/rnn_model.py
@@ -24,8 +24,11 @@ from .data_iterator import DataIterator
 
 
 class Inference:
-    def __init__(self, rnn):
+    def __init__(self, rnn, name='inference', batch_size=None, seq_len=None):
         self.rnn = rnn
+        self.name = name
+        self.batch_size = batch_size
+        self.seq_len = seq_len
         self.init_mod = None
         self.input_mods = []
         self._data_itr = None
@@ -33,12 +36,20 @@ class Inference:
         self.output_params = None
 
     @property
+    def effective_batch_size(self):
+        return self.batch_size or self.rnn.adjusted_batch_size
+
+    @property
+    def effective_seq_len(self):
+        return self.seq_len or self.rnn.adjusted_seq_len
+
+    @property
     def data_itr(self):
         if self._data_itr is None:
             self._data_itr = DataIterator(
                 input_mods=self.input_mods,
-                batch_size=self.rnn.adjusted_batch_size,
-                seq_len=self.rnn.adjusted_seq_len,
+                batch_size=self.effective_batch_size,
+                seq_len=self.effective_seq_len,
                 ordered_populations=self.rnn.ordered_inputs_populations
             )
             self._data_itr.build()
@@ -49,7 +60,7 @@ class Inference:
         if self.init_mod is None:
             return None
         else:
-            return self.init_mod.get_state()
+            return self.init_mod.get_state(batch_size=self.effective_batch_size)
 
     def close(self):
         if self._data_itr is not None:
@@ -445,16 +456,39 @@ class RNN:
 
         return self._state_only_model
 
-    def run_inference(self, spikes=None, initial_state=None, **kwargs):
+    def _select_inference(self, inference=None):
+        if inference is None:
+            if len(self._inferences) > 1:
+                raise ValueError(
+                    'Multiple inference conditions are configured. Specify the inference name or object.'
+                )
+            elif len(self._inferences) == 1:
+                return self._inferences[0]
+            else:
+                return None
+
+        if isinstance(inference, Inference):
+            return inference
+
+        for inference_obj in self._inferences:
+            if inference_obj.name == inference:
+                return inference_obj
+
+        raise ValueError(f'No inference condition named "{inference}".')
+
+    def run_inference(self, spikes=None, initial_state=None, inference=None, **kwargs):
         if not self._model_built:
             self.build()
+
+        inference_obj = None
+        if inference is not None or spikes is None or initial_state is None:
+            inference_obj = self._select_inference(inference)
         
         # Fetch the spikes
         if spikes is None:
-            if len(self._inferences) > 1:
-                raise NotImplementedError()
-            elif len(self._inferences) == 1:
-                spikes, y = self._inferences[0].data_itr.next_spikes()
+            if inference_obj is None:
+                raise ValueError('No inference input is configured. Pass spikes or add an inference block.')
+            spikes, y = inference_obj.data_itr.next_spikes()
         
         elif isinstance(spikes, DataIterator):
             spikes, y = spikes.next_spikes()
@@ -464,10 +498,8 @@ class RNN:
 
         # Fetch model init state
         if initial_state is None:
-            if len(self._inferences) > 1:
-                raise NotImplementedError()
-            elif len(self._inferences) == 1:
-                initial_state = self._inferences[0].get_initial_state()
+            if inference_obj is not None:
+                initial_state = inference_obj.get_initial_state()
        
         # Get version of model for pass-through only and reutrns spikes, voltages, and model states
         if self.extractor_model is None:
@@ -478,10 +510,12 @@ class RNN:
 
         # Run inputs through the model; fetch, package and return results
         out = self.extractor_model((spikes, initial_state))
+        result_seq_len = inference_obj.effective_seq_len if inference_obj is not None else self.seq_len
+        result_batch_size = inference_obj.effective_batch_size if inference_obj is not None else self.batch_size
         extractor_results = RNNExtractorResults(
-            seq_len=self.seq_len,
+            seq_len=result_seq_len,
             dt=self.dt,
-            batch_size=self.batch_size,
+            batch_size=result_batch_size,
             extractor_results=out
         )
         return extractor_results
@@ -537,16 +571,18 @@ class RNN:
             io.log_info('Training Model.')
             self.train()
 
-        results = None
-        if len(self._inferences) > 1:
-            raise NotImplementedError()
-        elif len(self._inferences) == 1:
-            io.log_info('Runing Inference on Model.')
-            results = self.run_inference()
-            inference = self._inferences[0]
+        results = {} if len(self._inferences) > 1 else None
+        for inference in self._inferences:
+            io.log_info(f'Runing Inference on Model ({inference.name}).')
+            inference_results = self.run_inference(inference=inference)
             if inference.output_params:
                 io.log_info('Saving Results to file.')
-                results.save_results(**inference.output_params)
+                inference_results.save_results(**inference.output_params)
+
+            if isinstance(results, dict):
+                results[inference.name] = inference_results
+            else:
+                results = inference_results
 
         io.log_info('RNN.run() completed.')
         return results
@@ -554,6 +590,66 @@ class RNN:
 
     def add_init_state(self, mod):
         self._init_state = mod
+
+    @staticmethod
+    def _normalized_inference_configs(inference_config):
+        if not inference_config:
+            return []
+
+        if isinstance(inference_config, list):
+            return inference_config
+
+        if not isinstance(inference_config, dict):
+            raise ValueError('The inference config must be a dictionary or list of dictionaries.')
+
+        inference_parameters = inference_config.get('parameters', None)
+        if inference_parameters is None:
+            return [inference_config]
+
+        shared_config = {key: value for key, value in inference_config.items() if key != 'parameters'}
+        normalized_configs = []
+        for parameter_config in inference_parameters:
+            if not isinstance(parameter_config, dict):
+                raise ValueError('Each inference parameter must be a dictionary.')
+
+            merged_config = {**shared_config, **parameter_config}
+            for key in ('initial_state', 'output'):
+                if isinstance(shared_config.get(key), dict) and isinstance(parameter_config.get(key), dict):
+                    merged_config[key] = {**shared_config[key], **parameter_config[key]}
+            normalized_configs.append(merged_config)
+
+        return normalized_configs
+
+    @classmethod
+    def _add_inferences_from_config(cls, network, config, inference_config):
+        inference_configs = cls._normalized_inference_configs(inference_config)
+        multiple_inferences = len(inference_configs) > 1
+
+        for inference_index, inference_dict in enumerate(inference_configs):
+            if 'inputs' not in inference_dict:
+                raise ValueError('Each inference config must include an "inputs" field.')
+
+            default_name = f'inference_{inference_index}' if multiple_inferences else 'inference'
+            inference = Inference(
+                rnn=network,
+                name=inference_dict.get('name', default_name),
+                batch_size=inference_dict.get('batch_size'),
+                seq_len=inference_dict.get('seq_len'),
+            )
+            for input_name, input_mod in network.parse_input_mods_from_config(inference_dict['inputs']):
+                inference.input_mods.append(input_mod)
+
+            init_state_dict = inference_dict.get('initial_state', {})
+            if init_state_dict:
+                module = init_state_dict['module']
+                mod_cls = StateModules().get_init_state_module(module)
+                inference.init_mod = mod_cls(rnn=network, **init_state_dict)
+
+            output = inference_dict.get('output', config.output)
+            if output is not None:
+                inference.output_params = output
+
+            network.add_inference(inference)
 
     '''
     def predict(self, spike_inputs, initial_state=None, **kwargs):
@@ -871,21 +967,7 @@ class RNN:
 
         inference_dict = config.get('inference', None)
         if inference_dict:
-            inference = Inference(rnn=network)
-            for input_name, input_mod in network.parse_input_mods_from_config(inference_dict['inputs']):
-                inference.input_mods.append(input_mod)
-
-            init_state_dict = inference_dict.get('initial_state', {})
-            if init_state_dict:
-                module = init_state_dict['module']
-                mod_cls = StateModules().get_init_state_module(module)
-                inference.init_mod = mod_cls(rnn=network, **init_state_dict)
-
-            output = inference_dict.get('output', config.output)
-            if output is not None:
-                inference.output_params = output
-
-            network.add_inference(inference)
+            cls._add_inferences_from_config(network, config, inference_dict)
 
 
         return network

--- a/bmtk/simulator/dpointnet/rnn_model.py
+++ b/bmtk/simulator/dpointnet/rnn_model.py
@@ -573,7 +573,7 @@ class RNN:
 
         results = {} if len(self._inferences) > 1 else None
         for inference in self._inferences:
-            io.log_info(f'Runing Inference on Model ({inference.name}).')
+            io.log_info(f'Running Inference on Model ({inference.name}).')
             inference_results = self.run_inference(inference=inference)
             if inference.output_params:
                 io.log_info('Saving Results to file.')

--- a/bmtk/simulator/dpointnet/rnn_model.py
+++ b/bmtk/simulator/dpointnet/rnn_model.py
@@ -369,7 +369,7 @@ class RNN:
                 shape=(None, n_neurons),
                 name='internal state inputs'
             )
-            full_inputs = tf.concat((extrn_inputs, internal_state_inputs), -1)
+            full_inputs = tf.keras.layers.Concatenate(axis=-1)([extrn_inputs, internal_state_inputs])
         else:
             state_input_holder = None
             full_inputs = extrn_inputs
@@ -389,7 +389,7 @@ class RNN:
                     tf.keras.layers.Input(shape=s.shape[1:], dtype=s.dtype, name=n)
                     for s, n in zip(self.zero_state, state_names)
                 )
-                rnn_initial_state = tf.nest.map_structure(tf.identity, initial_state_holder)
+                rnn_initial_state = list(initial_state_holder)
             else:
                 initial_state_holder = None
                 rnn_initial_state = self.zero_state
@@ -400,16 +400,16 @@ class RNN:
             rnn._autocast = False
             rnn_layer = rnn(full_inputs, initial_state=rnn_initial_state)
 
-            rnn_out = rnn_layer[0] if return_state else rnn_layer
+            rnn_out, _ = self._split_rnn_layer_output(rnn_layer)
             spikes_output = rnn_out[0]
 
             output = tf.keras.layers.Dense(n_output, name='projection', trainable=False)(spikes_output)
 
             if use_state_input:
                 if use_dummy_state_input:
-                    inputs = [extrn_inputs, state_input_holder, initial_state_holder]
+                    inputs = [extrn_inputs, state_input_holder] + list(initial_state_holder)
                 else:
-                    inputs = [extrn_inputs, initial_state_holder]
+                    inputs = [extrn_inputs] + list(initial_state_holder)
             else:
                 if use_dummy_state_input:
                     inputs = [extrn_inputs, state_input_holder]
@@ -417,8 +417,62 @@ class RNN:
                     inputs = [extrn_inputs]
 
             self.model = tf.keras.Model(inputs=inputs, outputs=[output])
-            self.model.build((_batch_size, _seq_len, n_spiking_inputs))
         self._model_built = True
+
+    def model_inputs(self, spikes, initial_state=None, state_inputs=None):
+        inputs = [spikes]
+        if state_inputs is not None:
+            inputs.append(state_inputs)
+        if initial_state is not None:
+            inputs.extend(tf.nest.flatten(initial_state))
+        return inputs
+
+    def _build_extractor_model(self):
+        rnn_out, rnn_state = self._split_rnn_layer_output(self.model.get_layer('rsnn').output)
+        return tf.keras.Model(
+            inputs=self.model.inputs,
+            outputs=list(rnn_out) + list(rnn_state)
+        )
+
+    def _split_rnn_layer_output(self, rnn_layer_output):
+        if isinstance(rnn_layer_output, (list, tuple)):
+            sequence_output = rnn_layer_output[0]
+            state_output = rnn_layer_output[1:]
+        else:
+            sequence_output = rnn_layer_output
+            state_output = []
+
+        if isinstance(sequence_output, (list, tuple)):
+            return list(sequence_output), list(state_output)
+
+        output_shape = sequence_output.shape
+        output_rank = getattr(output_shape, 'rank', None)
+        if output_rank is None and output_shape is not None:
+            output_rank = len(output_shape)
+
+        n_neurons = getattr(self._cell, '_n_neurons', None)
+        if n_neurons is not None and output_rank is not None and output_rank >= 3 and output_shape[-1] == n_neurons * 2:
+            return [sequence_output[..., :n_neurons], sequence_output[..., n_neurons:]], list(state_output)
+
+        if output_rank is not None and output_rank >= 4 and output_shape[0] == 2:
+            return [sequence_output[0], sequence_output[1]], list(state_output)
+        if output_rank is not None and output_rank >= 4 and output_shape[1] == 2:
+            return [sequence_output[:, 0], sequence_output[:, 1]], list(state_output)
+
+        return [sequence_output], list(state_output)
+
+    @staticmethod
+    def _unpack_extractor_output(flat_output):
+        flat_output = tuple(flat_output)
+        return ((flat_output[0], flat_output[1]),) + flat_output[2:]
+
+    def run_extractor(self, spikes, initial_state):
+        if self.extractor_model is None:
+            with self.strategy.scope():
+                self.extractor_model = self._build_extractor_model()
+        return self._unpack_extractor_output(
+            self.extractor_model(self.model_inputs(spikes, initial_state))
+        )
 
     @property
     def rsnn_layer(self):
@@ -450,7 +504,7 @@ class RNN:
             else:
                 state_out = state_rnn(full_inputs)
             self._state_only_model = tf.keras.Model(
-                inputs=self.model.inputs, 
+                inputs=self.model.inputs,
                 outputs=state_out[1:]
             )
 
@@ -502,14 +556,8 @@ class RNN:
                 initial_state = inference_obj.get_initial_state()
        
         # Get version of model for pass-through only and reutrns spikes, voltages, and model states
-        if self.extractor_model is None:
-            self.extractor_model = tf.keras.Model(
-                inputs=self.model.inputs, 
-                outputs=self.model.get_layer('rsnn').output
-            )
-
         # Run inputs through the model; fetch, package and return results
-        out = self.extractor_model((spikes, initial_state))
+        out = self.run_extractor(spikes, initial_state)
         result_seq_len = inference_obj.effective_seq_len if inference_obj is not None else self.seq_len
         result_batch_size = inference_obj.effective_batch_size if inference_obj is not None else self.batch_size
         extractor_results = RNNExtractorResults(
@@ -525,12 +573,9 @@ class RNN:
             inference.close()
 
     def train(self, training_engine=None):
-        with self.strategy.scope():
-            if self.extractor_model is None:
-                self.extractor_model = tf.keras.Model(
-                    inputs=self.model.inputs,
-                    outputs=self.model.get_layer('rsnn').output
-                )
+        if self.extractor_model is None:
+            with self.strategy.scope():
+                self.extractor_model = self._build_extractor_model()
 
         training_engine = training_engine or self.training_engine
         if training_engine is None:
@@ -539,15 +584,13 @@ class RNN:
         ## Build the optimizer (in strategy scope so its slot variables are created correctly)
         with self.strategy.scope():
             optimizer = training_engine.optimizer
+            if self.dtype == 'float16' and not optimizers.optimizer_supports_loss_scaling(optimizer):
+                # Prevent gradient underflow in mixed-float16 training. The wrapped optimizer
+                # must be built and applied as the active optimizer, especially under Keras 3.
+                from tensorflow.keras import mixed_precision as mixed_precision_module
+                optimizer = mixed_precision_module.LossScaleOptimizer(optimizer)
+                training_engine.set_optimizer(optimizer)
             optimizer.build(self.model.trainable_variables)
-
-        if self.dtype == 'float16':
-            # Prevent gradient underflow in mixed-float16 training. The wrapped optimizer
-            # must be set back on the engine so the train step scales the loss / unscales
-            # the gradients (scale_loss_for_optimizer only acts on a LossScaleOptimizer).
-            from tensorflow.keras import mixed_precision as mixed_precision_module
-            optimizer = mixed_precision_module.LossScaleOptimizer(optimizer)
-            training_engine.set_optimizer(optimizer)
 
         training_engine.train()
 
@@ -655,14 +698,14 @@ class RNN:
     def predict(self, spike_inputs, initial_state=None, **kwargs):
         if self.extractor_model is None:
             self.extractor_model = tf.keras.Model(
-                inputs=self.model.inputs, 
+                inputs=self.model.inputs,
                 outputs=self.model.get_layer('rsnn').output
             )
         
         if initial_state is None:
             initial_state = self.zero_state
 
-        out = self.extractor_model((spike_inputs, initial_state))
+        out = self.extractor_model(self.model_inputs(spike_inputs, initial_state))
         return out[0]
     '''
 
@@ -906,11 +949,12 @@ class RNN:
             # begging of training.
             optimizer_params = train_dict['optimizer']
             optimizer_name = optimizer_params['name']
-            optimizer = optimizers.create_optimizer(
-                optimizer=optimizer_name, 
-                learning_rate=learning_rate,
-                optimizer_params=optimizer_params, 
-            )
+            with network.strategy.scope():
+                optimizer = optimizers.create_optimizer(
+                    optimizer=optimizer_name,
+                    learning_rate=learning_rate,
+                    optimizer_params=optimizer_params,
+                )
             training_engine.set_optimizer(optimizer)
 
             ## Process "init_states"

--- a/bmtk/simulator/dpointnet/state_modules/cached_states.py
+++ b/bmtk/simulator/dpointnet/state_modules/cached_states.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 class CachedInitState:
     def __init__(self, file_paths, file_type='mixed', **kwargs):
+        self._rnn = kwargs.get('rnn')
         if file_paths is None:
             raise ValueError(f'CachedInitState: No file_paths specified, unable to load init_state.')
 
@@ -81,7 +82,8 @@ class CachedInitState:
 
         raise RuntimeError(f'Could not load {file_path}')
 
-    def get_state(self, rnn, **kwargs):
+    def get_state(self, rnn=None, **kwargs):
+        rnn = rnn or self._rnn
         selected_file = np.random.choice(self.all_cache_files)
         if not Path(selected_file).exists():
             raise FileExistsError(f'Could not find init_state file {selected_file}')

--- a/bmtk/simulator/dpointnet/state_modules/cached_states.py
+++ b/bmtk/simulator/dpointnet/state_modules/cached_states.py
@@ -84,6 +84,11 @@ class CachedInitState:
 
     def get_state(self, rnn=None, **kwargs):
         rnn = rnn or self._rnn
+        if rnn is None:
+            raise ValueError(
+                'CachedInitState requires an RNN instance. Pass rnn to get_state() '
+                'or construct CachedInitState with rnn=... .'
+            )
         selected_file = np.random.choice(self.all_cache_files)
         if not Path(selected_file).exists():
             raise FileExistsError(f'Could not find init_state file {selected_file}')

--- a/bmtk/simulator/dpointnet/state_modules/input_state.py
+++ b/bmtk/simulator/dpointnet/state_modules/input_state.py
@@ -14,38 +14,45 @@ class InitStateFromInputModule:
             self._input_mods[name] = mod
 
         self._init_state = None
+        self._init_state_batch_size = None
         self._spikes_itrs = None
+        self._spikes_itrs_batch_size = None
         self._last_state = None
 
-    @property
-    def init_state(self):
-        if self._init_state is None:
+    def init_state(self, batch_size=None):
+        batch_size = batch_size or self.rnn.adjusted_batch_size
+        if self._init_state is None or self._init_state_batch_size != batch_size:
             self._init_state = self.rnn.cell.zero_state(
-                self.rnn.adjusted_batch_size, 
+                batch_size,
                 self.rnn.dtype,
                 with_names=False
             )
+            self._init_state_batch_size = batch_size
         return self._init_state
 
-    @property
-    def spikes_itrs(self):
-        if self._spikes_itrs is None:
+    def spikes_itrs(self, batch_size=None):
+        batch_size = batch_size or self.rnn.adjusted_batch_size
+        if self._spikes_itrs is None or self._spikes_itrs_batch_size != batch_size:
+            if self._spikes_itrs is not None:
+                self._spikes_itrs.close()
             self._spikes_itrs = DataIterator(
                 input_mods=list(self._input_mods.values()), 
-                batch_size=self.rnn.adjusted_batch_size,
+                batch_size=batch_size,
                 seq_len=self.rnn.seq_len,
                 ordered_populations=self.rnn.ordered_inputs_populations
             )
+            self._spikes_itrs_batch_size = batch_size
 
         return self._spikes_itrs
 
-    def get_state(self, max_retries=8, **kwargs):
+    def get_state(self, max_retries=8, batch_size=None, **kwargs):
+        batch_size = batch_size or self.rnn.adjusted_batch_size
         last_err = None
         self.state_model = self.rnn.state_only_model
         for attempt in range(max_retries):
             try:
-                spikes_inputs, _ = self.spikes_itrs.next_spikes()
-                state_out = self.state_model([spikes_inputs, self.init_state])
+                spikes_inputs, _ = self.spikes_itrs(batch_size).next_spikes()
+                state_out = self.state_model([spikes_inputs, self.init_state(batch_size)])
                 self._last_state = state_out
                 return state_out
             except (tf.errors.InvalidArgumentError, tf.errors.UnknownError) as exc:
@@ -55,8 +62,8 @@ class InitStateFromInputModule:
                     f'(attempt {attempt + 1}/{max_retries}); rebuilding iterator and retrying.'
                 )
                 try:
-                    self.spikes_itrs.close()
-                    self.spikes_itrs.build()
+                    self.spikes_itrs(batch_size).close()
+                    self.spikes_itrs(batch_size).build()
                 except Exception:
                     pass
 

--- a/bmtk/simulator/dpointnet/state_modules/input_state.py
+++ b/bmtk/simulator/dpointnet/state_modules/input_state.py
@@ -52,7 +52,9 @@ class InitStateFromInputModule:
         for attempt in range(max_retries):
             try:
                 spikes_inputs, _ = self.spikes_itrs(batch_size).next_spikes()
-                state_out = self.state_model([spikes_inputs, self.init_state(batch_size)])
+                state_out = self.state_model(
+                    self.rnn.model_inputs(spikes_inputs, self.init_state(batch_size))
+                )
                 self._last_state = state_out
                 return state_out
             except (tf.errors.InvalidArgumentError, tf.errors.UnknownError) as exc:

--- a/bmtk/simulator/dpointnet/state_modules/randomized_state.py
+++ b/bmtk/simulator/dpointnet/state_modules/randomized_state.py
@@ -87,8 +87,9 @@ class RandomizedStateModule:
 
         return self._function_ptrs
 
-    def get_state(self, rnn, batch_size=None, **kwargs):
-        self._rnn = rnn
+    def get_state(self, rnn=None, batch_size=None, **kwargs):
+        if rnn is not None:
+            self._rnn = rnn
         batch_size = batch_size or self._rnn.batch_size
-        state_vals = [f(batch_size=rnn.batch_size) for f in self.function_pointers]
+        state_vals = [f(batch_size=batch_size) for f in self.function_pointers]
         return state_vals

--- a/bmtk/simulator/dpointnet/state_modules/zero_state.py
+++ b/bmtk/simulator/dpointnet/state_modules/zero_state.py
@@ -5,5 +5,5 @@ class ZeroStateModule:
         # self._batch_size = self._rnn.batch_size
         self._dtype = self._rnn.dtype
 
-    def get_state(self, **kwargs):
-        return self._rnn.cell.zero_state(self._rnn.adjusted_batch_size, self._dtype)
+    def get_state(self, batch_size=None, **kwargs):
+        return self._rnn.cell.zero_state(batch_size or self._rnn.adjusted_batch_size, self._dtype)

--- a/bmtk/simulator/dpointnet/training.py
+++ b/bmtk/simulator/dpointnet/training.py
@@ -355,7 +355,7 @@ class TrainingEngine:
             if x.dtype == tf.bool:
                 x = tf.cast(x, self.rnn.dtype)
             return self._extractor_forward(x, init_state)
-        return self.rnn.extractor_model((x, init_state))
+        return self.rnn.run_extractor(x, init_state)
 
     @staticmethod
     def _add_gradients(accumulated, current):
@@ -610,7 +610,7 @@ class TrainingEngine:
             all_losses = []
             for p, x, y in zip(self.parameters, xs, ys):
                 loss_vals[p.name] = {}
-                _out = self.rnn.extractor_model((x, init_state))
+                _out = self.rnn.run_extractor(x, init_state)
                 _spikes_out, _v_out = _out[0]
                 _model_state = _out[1:]
                 loss_vals[p.name]['__mean_rate'] = tf.cast(tf.reduce_mean(_spikes_out), tf.float32)
@@ -638,7 +638,7 @@ class TrainingEngine:
         elif training_approach == 'parallel':
             x_concat = tf.concat(xs, axis=0)
             sigs = self.inputs_signature_factory.build(ys)
-            _out = self.rnn.extractor_model((x_concat, init_state))
+            _out = self.rnn.run_extractor(x_concat, init_state)
             _spikes_out, _v_out = _out[0]
             _model_state = _out[1:]
 
@@ -759,7 +759,8 @@ class TrainingEngine:
             def extractor_forward(x, fwd_init_state):
                 if x.dtype == tf.bool:
                     x = tf.cast(x, self.rnn.dtype)
-                return self.rnn.extractor_model((x, fwd_init_state))
+                flat_out = self.rnn.extractor_model(self.rnn.model_inputs(x, fwd_init_state))
+                return self.rnn._unpack_extractor_output(flat_out)
             self._extractor_forward = extractor_forward
 
         try:

--- a/tests/simulator/dpointnet/test_lgn_generator.py
+++ b/tests/simulator/dpointnet/test_lgn_generator.py
@@ -1,5 +1,8 @@
 from pathlib import Path
+import inspect
 from types import SimpleNamespace
+
+import tensorflow as tf
 
 import bmtk.simulator.dpointnet.input_modules.lgn_generator as lgn_generator
 
@@ -66,3 +69,48 @@ def test_lgn_generator_honors_custom_cache_file_and_overwrite(tmp_path, monkeypa
     assert kwargs['temp_krns_path'] == str(stale_files[1])
     assert kwargs['spatial_krns_path'] == str(stale_files[2])
     assert all(not file_path.exists() for file_path in stale_files)
+
+
+def test_drifting_gratings_phase_is_keyword_compatible_and_cast(monkeypatch):
+    signature = inspect.signature(lgn_generator.create_drifting_gratings_generator)
+    parameters = list(signature.parameters)
+    assert parameters.index('phase') > parameters.index('seed')
+
+    captured = {}
+
+    def make_movie(**kwargs):
+        captured['phase'] = kwargs['phase']
+        return tf.zeros((kwargs['image_duration'], kwargs['row_size'], kwargs['col_size']), dtype=kwargs['dtype'])
+
+    class DummyLGNNetwork:
+        n_nodes = 2
+
+        def spatial_response(self, videos, bmtk_compat):
+            return (videos,)
+
+        def firing_rates_from_spatial(self, videos):
+            return tf.ones((5, self.n_nodes), dtype=tf.float16)
+
+    monkeypatch.setattr(lgn_generator, 'make_drifting_grating_stimulus', make_movie)
+    monkeypatch.setattr(
+        lgn_generator,
+        'movies_concat',
+        lambda movie, pre_delay, post_delay, dtype: movie,
+    )
+
+    dataset = lgn_generator.create_drifting_gratings_generator(
+        DummyLGNNetwork(),
+        5,
+        [0],
+        2,
+        0.04,
+        0.8,
+        3,
+        4,
+        current_input=True,
+        dtype=tf.float16,
+        phase=90,
+    )
+    next(iter(dataset))
+
+    assert captured['phase'].dtype == tf.float16

--- a/tests/simulator/dpointnet/test_multi_inference.py
+++ b/tests/simulator/dpointnet/test_multi_inference.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from bmtk.simulator.dpointnet.rnn_model import Inference, RNN
+from bmtk.simulator.dpointnet.state_modules.cached_states import CachedInitState
 
 
 class DummyResults:
@@ -172,3 +173,12 @@ def test_inference_initial_state_uses_inference_batch_size():
 
     assert inference.get_initial_state() == 'state-batch-1'
     assert inference.init_mod.batch_sizes == [1]
+
+
+def test_cached_init_state_requires_rnn(tmp_path):
+    cache_file = tmp_path / 'state.npz'
+    cache_file.write_bytes(b'not-used')
+    init_state = CachedInitState(str(cache_file), file_type='npz')
+
+    with pytest.raises(ValueError, match='requires an RNN instance'):
+        init_state.get_state()

--- a/tests/simulator/dpointnet/test_multi_inference.py
+++ b/tests/simulator/dpointnet/test_multi_inference.py
@@ -1,0 +1,174 @@
+from types import SimpleNamespace
+
+import pytest
+
+from bmtk.simulator.dpointnet.rnn_model import Inference, RNN
+
+
+class DummyResults:
+    def __init__(self, name):
+        self.name = name
+        self.saved_outputs = []
+
+    def save_results(self, **kwargs):
+        self.saved_outputs.append(kwargs)
+
+
+class DummyRNN(RNN):
+    def __init__(self):
+        self._model_built = True
+        self._inferences = []
+        self.runs = []
+
+    def build(self):
+        self._model_built = True
+
+    @property
+    def training_engine(self):
+        return None
+
+    def run_inference(self, spikes=None, initial_state=None, inference=None, **kwargs):
+        inference_obj = self._select_inference(inference)
+        self.runs.append(inference_obj.name)
+        return DummyResults(inference_obj.name)
+
+
+class DummyStateModule:
+    def __init__(self):
+        self.batch_sizes = []
+
+    def get_state(self, batch_size=None):
+        self.batch_sizes.append(batch_size)
+        return f'state-batch-{batch_size}'
+
+
+def test_normalized_inference_configs_keeps_legacy_schema():
+    inference = {
+        'inputs': ['lgn_dg0', 'bkg'],
+        'initial_state': {'module': 'zero_state'},
+        'output': {'output_dir': 'out', 'spikes_file': 'spikes.h5'},
+    }
+
+    assert RNN._normalized_inference_configs(inference) == [inference]
+
+
+def test_normalized_inference_configs_expands_parameter_schema():
+    inference = {
+        'initial_state': {'module': 'zero_state'},
+        'output': {'log_level': 'INFO'},
+        'parameters': [
+            {
+                'name': 'dg0',
+                'inputs': ['lgn_dg0', 'bkg'],
+                'output': {'output_dir': 'out_dg0', 'spikes_file': 'spikes_dg0.h5'},
+            },
+            {
+                'name': 'dg180',
+                'inputs': ['lgn_dg180', 'bkg'],
+                'output': {'output_dir': 'out_dg180', 'spikes_file': 'spikes_dg180.h5'},
+            },
+        ],
+    }
+
+    configs = RNN._normalized_inference_configs(inference)
+
+    assert [config['name'] for config in configs] == ['dg0', 'dg180']
+    assert configs[0]['initial_state'] == {'module': 'zero_state'}
+    assert configs[0]['output'] == {
+        'log_level': 'INFO',
+        'output_dir': 'out_dg0',
+        'spikes_file': 'spikes_dg0.h5',
+    }
+    assert configs[1]['output'] == {
+        'log_level': 'INFO',
+        'output_dir': 'out_dg180',
+        'spikes_file': 'spikes_dg180.h5',
+    }
+
+
+def test_run_executes_all_inferences_and_returns_results_by_name():
+    network = DummyRNN()
+    dg0 = Inference(network, name='dg0')
+    dg0.output_params = {'output_dir': 'out_dg0', 'spikes_file': 'spikes_dg0.h5'}
+    dg180 = Inference(network, name='dg180')
+    dg180.output_params = {'output_dir': 'out_dg180', 'spikes_file': 'spikes_dg180.h5'}
+    network.add_inference(dg0)
+    network.add_inference(dg180)
+
+    results = network.run()
+
+    assert network.runs == ['dg0', 'dg180']
+    assert list(results) == ['dg0', 'dg180']
+    assert results['dg0'].saved_outputs == [{'output_dir': 'out_dg0', 'spikes_file': 'spikes_dg0.h5'}]
+    assert results['dg180'].saved_outputs == [{'output_dir': 'out_dg180', 'spikes_file': 'spikes_dg180.h5'}]
+
+
+def test_add_inferences_from_config_builds_named_conditions(monkeypatch):
+    network = DummyRNN()
+    parsed_inputs = []
+
+    def parse_input_mods_from_config(input_names):
+        parsed_inputs.append(input_names)
+        return [(input_name, SimpleNamespace(name=input_name)) for input_name in input_names]
+
+    network.parse_input_mods_from_config = parse_input_mods_from_config
+    config = SimpleNamespace(output=None)
+    inference = {
+        'initial_state': {'module': 'zero_state'},
+        'batch_size': 1,
+        'seq_len': 500,
+        'parameters': [
+            {
+                'name': 'dg0',
+                'inputs': ['lgn_dg0', 'bkg'],
+                'output': {'output_dir': 'out_dg0'},
+            },
+            {
+                'name': 'dg180',
+                'inputs': ['lgn_dg180', 'bkg'],
+                'output': {'output_dir': 'out_dg180'},
+            },
+        ],
+    }
+
+    class ZeroState:
+        def __init__(self, rnn, **kwargs):
+            self.rnn = rnn
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(
+        'bmtk.simulator.dpointnet.rnn_model.StateModules.get_init_state_module',
+        lambda self, module: ZeroState,
+    )
+
+    RNN._add_inferences_from_config(network, config, inference)
+
+    assert [inference.name for inference in network._inferences] == ['dg0', 'dg180']
+    assert [inference.batch_size for inference in network._inferences] == [1, 1]
+    assert [inference.seq_len for inference in network._inferences] == [500, 500]
+    assert parsed_inputs == [['lgn_dg0', 'bkg'], ['lgn_dg180', 'bkg']]
+    assert [inference.output_params for inference in network._inferences] == [
+        {'output_dir': 'out_dg0'},
+        {'output_dir': 'out_dg180'},
+    ]
+    assert all(inference.init_mod.kwargs == {'module': 'zero_state'} for inference in network._inferences)
+
+
+def test_run_inference_requires_name_when_multiple_inferences_are_configured():
+    network = DummyRNN()
+    network.add_inference(Inference(network, name='dg0'))
+    network.add_inference(Inference(network, name='dg180'))
+
+    with pytest.raises(ValueError, match='Multiple inference conditions'):
+        network._select_inference()
+
+    assert network._select_inference('dg180').name == 'dg180'
+
+
+def test_inference_initial_state_uses_inference_batch_size():
+    network = SimpleNamespace(adjusted_batch_size=2, adjusted_seq_len=500)
+    inference = Inference(network, name='dg0', batch_size=1, seq_len=500)
+    inference.init_mod = DummyStateModule()
+
+    assert inference.get_initial_state() == 'state-batch-1'
+    assert inference.init_mod.batch_sizes == [1]

--- a/tests/simulator/dpointnet/test_synchronization_loss.py
+++ b/tests/simulator/dpointnet/test_synchronization_loss.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from bmtk.simulator.dpointnet.loss_functions import loss_utils
+from bmtk.simulator.dpointnet.loss_functions.synchronization_loss import SynchronizationLoss
+
+
+def _build_dummy_rnn():
+    return SimpleNamespace(
+        recurrent_network={
+            'n_nodes': 4,
+            'node_params': {
+                'pop_name': ['e0', 'i0', 'e1', 'i1'],
+            },
+        }
+    )
+
+
+def test_synchronization_loss_uses_millisecond_window(monkeypatch):
+    loaded_paths = []
+
+    monkeypatch.setattr(loss_utils, 'get_pop_names', lambda network: np.array(['e0', 'i0', 'e1', 'i1']))
+    monkeypatch.setattr('os.path.exists', lambda path: True)
+
+    def fake_load(path, allow_pickle=True):
+        loaded_paths.append(path)
+        return np.ones((3, 20), dtype=np.float32)
+
+    monkeypatch.setattr(np, 'load', fake_load)
+
+    loss = SynchronizationLoss(
+        _build_dummy_rnn(),
+        t_start=200,
+        t_end=500,
+        neuropixels_data_dir='Synchronization_data',
+    )
+
+    assert loss._t_start_idx == 200
+    assert loss._t_end_idx == 500
+    assert loaded_paths == ['Synchronization_data/Fano_factor_v1/v1_fano_running_300ms_evoked.npy']
+
+
+def test_synchronization_loss_rejects_second_style_window(monkeypatch):
+    monkeypatch.setattr(loss_utils, 'get_pop_names', lambda network: np.array(['e0', 'i0', 'e1', 'i1']))
+    monkeypatch.setattr('os.path.exists', lambda path: True)
+    monkeypatch.setattr(np, 'load', lambda path, allow_pickle=True: np.ones((3, 20), dtype=np.float32))
+
+    with pytest.raises(ValueError, match='multiply by 1000.*t_start=200, t_end=500'):
+        SynchronizationLoss(_build_dummy_rnn(), t_start=0.2, t_end=0.5)


### PR DESCRIPTION
Adds multi-condition post-training inference support for dpointnet training configs, so training can automatically run and save inference outputs for multiple input conditions after the training loop completes.

Changes
- Support `inference.parameters` with shared defaults plus per-condition overrides.
- Allow each inference condition to set its own `inputs`, `output`, `batch_size`, and `seq_len`.
- Fix inference initial-state batch sizing so post-training inference can use a different batch size than parallel training.
- Add tests covering multi-inference config expansion, execution, saving, and batch-size propagation.

Validation
- `pytest tests/simulator/dpointnet/test_multi_inference.py`
- Zero-epoch Step 1 smoke run completed both embedded inference outputs (`dg0`, `dg180`) successfully.