### PR TITLE
Updating contributors

### DIFF
--- a/docs/autodocs/source/contributors.rst
+++ b/docs/autodocs/source/contributors.rst
@@ -5,36 +5,48 @@ Anton Arkhipov `@antonarkhipov <http://github.com/antonarkhipov>`__
 
 Fahimeh Baftizadeh `@Fahimeh1983 <http://github.com/Fahimeh1983>`__
 
+Tyler Banks `@tjbanks <http://github.com/tjbanks>`__
+
 Yazan Billeh `@CellAssembly <http://github.com/CellAssembly>`__
 
 Michael Buice `@mabuice <http://github.com/mabuice>`__
 
 Nicholas Cain `@nicain <http://github.com/nicain>`__
 
+Guozhang Chen `@ifgovh <https://github.com/ifgovh>`__
+
 Kael Dai `@kaeldai <http://github.com/kaeldai>`__
 
 David Feng `@dyf <http://github.com/dyf>`__
+
+Javier Galván Fraile `@JavierGalvan9 <https://github.com/JavierGalvan9>`__
 
 Natan Gouwens `@gouwens <http://github.com/gouwens>`__
 
 Sergey Gratiy `@sgratiy <http://github.com/sgratiy>`__
 
+Shinya Ito `@shixnya <https://github.com/shixnya>`__
+
 Ram Iyer `@ramakrishnaniyer <http://github.com/ramakrishnaniyer>`__
+
+Ben Latimer `@latimerb <https://github.com/latimerb>`__
 
 Jung Hoon Lee
 
 Xiao-Ping Liu `@xpliu16 <http://github.com/xpliu16>`__
 
+Wolfgang Maass
+
 Stefan Mihalas
 
+Claudio Mirasso
+
 Catalin Mitelut
+
+Franz Scherr `@franzscherr <https://github.com/franzscherr>`__
+
+Nils Van Rompaey `@nilsvanrompaey <https://github.com/nilsvanrompaey>`__
 
 Yina Wei
 
 Richard Xu
-
-Tyler Banks `@tjbanks <http://github.com/tjbanks>`__
-
-Ben Latimer `@latimerb <https://github.com/latimerb>`__
-
-Nils Van Rompaey `@nilsvanrompaey <https://github.com/nilsvanrompaey>`__

--- a/docs/autodocs/source/publications.rst
+++ b/docs/autodocs/source/publications.rst
@@ -35,6 +35,8 @@ The BioNet module of BMTK was described in an earlier paper. If using BioNet, pl
 
 **How to cite the V1 models:**
 
-Development of BMTK and SONATA was driven to a large degree by our efforts to model cortical circuits. Models of the mouse primary visual cortex (area V1) are `publicly available here <https://portal.brain-map.org/explore/models/mv1-all-layers>`_ and should be cited as follows:
+Development of BMTK and SONATA was driven to a large degree by our efforts to model cortical circuits. Models of the mouse primary visual cortex (area V1) are `publicly available here <https://brain-map.org/our-research/computational-modelling>`_ and should be cited as follows:
 
-[1] Billeh, Y. N., Cai, B., Gratiy, S. L., Dai, K., Iyer, R., Gouwens, N. W., Abbasi-Asl, R., Jia, X., Siegle, J. H., Olsen, S. R., Koch, C., Mihalas, S., & Arkhipov, A. (2020). Systematic Integration of Structural and Functional Data into Multi-scale Models of Mouse Primary Visual Cortex. Neuron, 106(3), 388-403.e18. https://doi.org/10.1016/j.neuron.2020.01.040 
+[1] 2026 V1 model: Ito, S., Haufler, D., Fraile, J. G., Dai, K., Aman, J., Chen, G., Mirasso, C., Maass, W., & Arkhipov, A. (2026). Deep-learning-assisted simulation of a cortical circuit: integrating anatomy, physiology and function. bioRxiv, 2026.03.13.711751. https://doi.org/10.64898/2026.03.13.711751
+
+[2] 2020 V1 model: Billeh, Y. N., Cai, B., Gratiy, S. L., Dai, K., Iyer, R., Gouwens, N. W., Abbasi-Asl, R., Jia, X., Siegle, J. H., Olsen, S. R., Koch, C., Mihalas, S., & Arkhipov, A. (2020). Systematic Integration of Structural and Functional Data into Multi-scale Models of Mouse Primary Visual Cortex. Neuron, 106(3), 388-403.e18. https://doi.org/10.1016/j.neuron.2020.01.040


### PR DESCRIPTION
Added myself, folks in the Maass and Mirasso labs to Contributors.
Sorted with alphabetic order.
Citations page now adds Ito 2026, and point to the modeling top page, instead of the Billeh model page.